### PR TITLE
fix: linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,4 +22,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84
         with:
-          version: v1.64
+          version: v2.0.2

--- a/pkg/layer2/loaders.go
+++ b/pkg/layer2/loaders.go
@@ -16,7 +16,9 @@ func loadYamlFromURL(sourcePath string, data interface{}) error {
 	if err != nil {
 		return fmt.Errorf("failed to fetch URL: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close()
+	}()
 
 	if resp.StatusCode != http.StatusOK {
 		return fmt.Errorf("failed to fetch URL; response status: %v", resp.Status)
@@ -43,7 +45,9 @@ func loadYaml(sourcePath string, data interface{}) error {
 		return fmt.Errorf("error opening file: %w", err)
 	}
 
-	defer file.Close()
+	defer func() {
+		_ = file.Close()
+	}()
 	decoder := yaml.NewDecoder(file)
 	decoder.KnownFields(true)
 


### PR DESCRIPTION
- [x] use latest golangci-lint version (v2.0.2)
- [x] fix new linting issues (errors in defer)