### PR TITLE
feat: layer 4 schema changes for discussion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,10 @@ jobs:
       - uses: actions/checkout@v4.2.2
       - name: Setup Cue
         uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
-      - name: Validate the layer 2 schema
+      - name: Validate the schema
         run: make lintcue
+      - name: Validate the examples
+        run: make lintexamples
       - uses: actions/setup-go@v5.4.0
         with:
           go-version: "^1.23.4"

--- a/Makefile
+++ b/Makefile
@@ -69,3 +69,10 @@ lintcue:
 	@cue eval ./schemas/layer-2.cue --all-errors --verbose
 	@echo "  >  Linting layer-4.cue ..."
 	@cue eval ./schemas/layer-4.cue --all-errors --verbose
+
+lintexamples:
+	@echo "  >  Linting example files ..."
+	@echo "  >  Linting schemas/example_evaluation_results ..."
+	@cue vet schemas/layer-4.cue schemas/example_evaluation_results.yml -d '#Layer4'
+
+PHONY: lintcue lintexamples

--- a/schemas/example_evaluation_results.yml
+++ b/schemas/example_evaluation_results.yml
@@ -1,8 +1,9 @@
-frameworkID: OSPS
+catalog_id: OSPS
+corrupted_state: false
 evaluations:
-  - controlID: "OSPS-BR-01"
+  - control_id: "OSPS-BR-01"
     assessments:
-      - requirementID: "OSPS-BR-01.01"
+      - requirement_id: "OSPS-BR-01.01"
         methods:
           - name: "Manual review of CI pipelines used by the project"
             description: "Manually review the CI pipelines for proper handling of user-controlled build inputs."
@@ -15,7 +16,7 @@ evaluations:
             run: true
             result:
               status: needs_review
-      - requirementID: "OSPS-BR-01.02"
+      - requirement_id: "OSPS-BR-01.02"
         methods:
           - name: "Manual review of CI pipelines used by the project"
             description: "Manually review the CI pipelines for proper handling of branch-name build inputs."

--- a/schemas/example_evaluation_results.yml
+++ b/schemas/example_evaluation_results.yml
@@ -1,8 +1,6 @@
-name: Open Source Security Baseline
 frameworkID: OSPS
 evaluations:
-  - name: "OSPS BR Controls Evaluation"
-    controlID: "OSPS-BR-01"
+  - controlID: "OSPS-BR-01"
     assessments:
       - requirementID: "OSPS-BR-01.01"
         methods:

--- a/schemas/example_evaluation_results.yml
+++ b/schemas/example_evaluation_results.yml
@@ -1,0 +1,34 @@
+name: Open Source Security Baseline
+frameworkID: OSPS
+evaluations:
+  - name: "OSPS BR Controls Evaluation"
+    controlID: "OSPS-BR-01"
+    assessments:
+      - requirementID: "OSPS-BR-01.01"
+        methods:
+          - name: "Manual review of CI pipelines used by the project"
+            description: "Manually review the CI pipelines for proper handling of user-controlled build inputs."
+            run: false
+          - name: "One time SAST scan of GitHub Actions workflows"
+            description: "GitHub Actions-specific SAST scan run against all contents of `.github/workflows`."
+            run: false
+          - name: "Ongoing CodeQL SAST scanning of GitHub Actions workflows"
+            description: "Project is configured to run regular CodeQL SAST scans of GitHub Actions workflows."
+            run: true
+            result:
+              status: needs_review
+      - requirementID: "OSPS-BR-01.02"
+        methods:
+          - name: "Manual review of CI pipelines used by the project"
+            description: "Manually review the CI pipelines for proper handling of branch-name build inputs."
+            run: false
+          - name: "One time SAST scan of GitHub Actions workflows"
+            description: "GitHub Actions-specific SAST scan run against all contents of `.github/workflows`."
+            run: true
+            result:
+              status: passed
+          - name: "Ongoing CodeQL SAST scanning of GitHub Actions workflows"
+            description: "Project is configured to run regular CodeQL SAST scans of GitHub Actions workflows."
+            run: true
+            result:
+              status: passed

--- a/schemas/layer-4.cue
+++ b/schemas/layer-4.cue
@@ -21,9 +21,6 @@ package schemas
 
 // ControlEvaluation describes the evaluation of the layer 2 control referenced by controlID and the assessment of that control's requirements.
 #ControlEvaluation: {
-    // name of the control being evaluated
-    // TODO: why materialize/duplicate this data here if a consumer can simply reference the layer 2 data?
-    name: string
     // ID of the layer 2 control being evaluated
     controlID: string
     // TODO: should there also be a frameworkID here to make a ControlEvaluation more self-contained?
@@ -50,7 +47,7 @@ package schemas
     description: string
     // Run is a boolean indicating whether the method was run or not. When run is true, result is expected to be present.
     run: bool
-    // Remediation guide is a ¯\_(ツ)_/¯
+    // Remediation guide is a URL to remediation guidance associated with the control's assessment requirement and this specific assessment method.
     remediation_guide?: #URL
 }
 
@@ -69,11 +66,12 @@ package schemas
 }
 
 // AssessmentResult describes the result of the assessment of a layer 2 control requirement.
-//  * passed when all evidence suggests the control is met
-//  * failed when some evidence suggests the control is not met
-//  * needs_review when evidence was gathered but cannot be reliably interpreted to reach a decision. A human should review the evidence gathered
-//  * error when the method failed to execute
 #AssessmentResult: {
+    // status describes what happened when the assessment method was run
+    //  * passed when all evidence suggests the control is met
+    //  * failed when some evidence suggests the control is not met
+    //  * needs_review when evidence was gathered but cannot be reliably interpreted to reach a decision. A human should review the evidence gathered
+    //  * error when the method failed to execute
     status: #Status
     // TODO: I can imagine assessment methods potentially making more than a single change, perhaps this should be a list
     change?: #Change

--- a/schemas/layer-4.cue
+++ b/schemas/layer-4.cue
@@ -12,7 +12,7 @@ package schemas
     // TODO: in the case of versioned frameworks (ex: NIST 800-53), should we expect the version to be part of the ID?
     frameworkID: string
     // one or more evaluations of the framework controls
-    evaluations: [#ControlEvaluation, ...#ControlEvaluation]
+    control_evaluations: [#ControlEvaluation, ...#ControlEvaluation]
 }
 
 // URL describes a specific subset of URLs of interest to the framework
@@ -22,7 +22,7 @@ package schemas
 // ControlEvaluation describes the evaluation of the layer 2 control referenced by controlID and the assessment of that control's requirements.
 #ControlEvaluation: {
     // ID of the layer 2 control being evaluated
-    controlID: string
+    control_id: string
     // TODO: should there also be a frameworkID here to make a ControlEvaluation more self-contained?
     // one or more assessments of the control requirements
     // TODO: should it be 0 or more to account for an evaluation where planning is "in-progress" for which assessments should be run?
@@ -31,16 +31,14 @@ package schemas
 
 // Assessment describes the evaluation of layer 2 control requirement referenced by requirementID and the assessment methods used to assess that requirement.
 #Assessment: {
-    // TODO: should there also be frameworkID and controlID here to make a Assessment more self-contained?
-    // ID of the layer 2 control requirement being evaluated
-    requirementID: string
+    // ID of the Layer 2 Control's Requirement being evaluated
+    requirement_id: string
     // the methods used to assess the requirement
     methods: [#AssessmentMethod, ...#AssessmentMethod]
 }
 
 // AssessmentMethod describes the method used to assess the layer 2 control requirement referenced by requirementID.
 #AssessmentMethod: {
-    // TODO: should there also be frameworkID and controlID here to make a AssessmentMethod more self-contained?
     // Name is the name of the method used to assess the requirement.
     name: string
     // Description is a detailed explanation of the method.
@@ -85,7 +83,7 @@ package schemas
 #Change: {
     // TODO: document all fields here with more clarity once we have one or more examples of existing usage/dependency/necessity
     // target name is ¯\_(ツ)_/¯
-    "target-name": string
+    target_name: string
     // applied describes whether the change was applied to the system(s) under assessment
     applied: bool
     // reverted describes whether the change was reverted from the system(s) under assessment
@@ -93,5 +91,5 @@ package schemas
     // error describes whether an error occurred during either the application or reversion of the change
     error?: string
     // target object is ¯\_(ツ)_/¯
-    "target-object"?: _
+    target_object?: _
 }

--- a/schemas/layer-4.cue
+++ b/schemas/layer-4.cue
@@ -8,30 +8,92 @@ package schemas
 
 #ControlEvaluation: {
     name: string
-    "control-id": string
-    result: #Result
-    message: string
-    "documentation-url"?: =~"^https?://[^\\s]+$"
-    "corrupted-state"?: bool
-    "assessment-results"?: [...#AssessmentResult]
+    // frameworkID contains the unique identifier of the framework being evaluated
+    // TODO: in the case of versioned frameworks (ex: NIST 800-53), should we expect the version to be part of the ID?
+    frameworkID: string
+    // one or more evaluations of the framework controls
+    evaluations: [#ControlEvaluation, ...#ControlEvaluation]
 }
 
-#AssessmentResult: {
-    result: #Result
+// URL describes a specific subset of URLs of interest to the framework
+// TODO: this definition should be imported from a more appropriate module/package
+#URL: =~"^https?://[^\\s]+$"
+
+// ControlEvaluation describes the evaluation of the layer 2 control referenced by controlID and the assessment of that control's requirements.
+#ControlEvaluation: {
+    // name of the control being evaluated
+    // TODO: why materialize/duplicate this data here if a consumer can simply reference the layer 2 data?
+    name: string
+    // ID of the layer 2 control being evaluated
+    controlID: string
+    // TODO: should there also be a frameworkID here to make a ControlEvaluation more self-contained?
+    // one or more assessments of the control requirements
+    // TODO: should it be 0 or more to account for an evaluation where planning is "in-progress" for which assessments should be run?
+    assessments: [#Assessment, ...#Assessment]
+}
+
+// Assessment describes the evaluation of layer 2 control requirement referenced by requirementID and the assessment methods used to assess that requirement.
+#Assessment: {
+    // TODO: should there also be frameworkID and controlID here to make a Assessment more self-contained?
+    // ID of the layer 2 control requirement being evaluated
+    requirementID: string
+    // the methods used to assess the requirement
+    methods: [#AssessmentMethod, ...#AssessmentMethod]
+}
+
+// AssessmentMethod describes the method used to assess the layer 2 control requirement referenced by requirementID.
+#AssessmentMethod: {
+    // TODO: should there also be frameworkID and controlID here to make a AssessmentMethod more self-contained?
+    // Name is the name of the method used to assess the requirement.
+    name: string
+    // Description is a detailed explanation of the method.
+    description: string
+    // Run is a boolean indicating whether the method was run or not. When run is true, result is expected to be present.
+    run: bool
+    // Remediation guide is a ¯\_(ツ)_/¯
+    remediation_guide?: #URL
+}
+
+// See https://cuelang.org/docs/tour/types/sumstruct/
+#AssessmentMethod: {
     name: string
     description: string
-    message: string
-    "function-address": string
-    change?: #Change
-    value?: _
+    run: false
+    remediation_guide?: #URL
+} | {
+    name: string
+    description: string
+    run: true
+    remediation_guide?: #URL
+    result!: #AssessmentResult
 }
 
-#Result: "Passed" | "Failed" | "Needs Review"
+// AssessmentResult describes the result of the assessment of a layer 2 control requirement.
+//  * passed when all evidence suggests the control is met
+//  * failed when some evidence suggests the control is not met
+//  * needs_review when evidence was gathered but cannot be reliably interpreted to reach a decision. A human should review the evidence gathered
+//  * error when the method failed to execute
+#AssessmentResult: {
+    status: #Status
+    // TODO: I can imagine assessment methods potentially making more than a single change, perhaps this should be a list
+    change?: #Change
+}
 
+// Status constrains the acceptable values describing the result of the assessment of a level 2 control requirement.
+#Status: "passed" | "failed" | "needs_review" | "error"
+
+// Change describes whether the execution of an automated assessment of a layer 2 control requirement resulted in changes being made to the system(s) under assessment.
+// TODO: flesh out more once we have one or more examples of existing usage/dependency/necessity
 #Change: {
+    // TODO: document all fields here with more clarity once we have one or more examples of existing usage/dependency/necessity
+    // target name is ¯\_(ツ)_/¯
     "target-name": string
+    // applied describes whether the change was applied to the system(s) under assessment
     applied: bool
+    // reverted describes whether the change was reverted from the system(s) under assessment
     reverted: bool
+    // error describes whether an error occurred during either the application or reversion of the change
     error?: string
+    // target object is ¯\_(ツ)_/¯
     "target-object"?: _
 }


### PR DESCRIPTION
Understanding the intent and reasoning behind schema choices is
difficult without clear documentation. All of the definitions and
fields in the layer4 schema are now documented and the example data
file in `schemas/example_evaluation_results.yml` should help
further explain the schema.

 * snake case is adopted for all field names
 * Struct disjunction is introduced to correctly specify a constraint between the execution status of AssessmentMethod and the presence of a result
 * List bounds are refined to more correctly specify the number of expected items and the expected type constraints for those items
 * `@Go` annotations are added to show the desired/resulting Go type/field names where needed to cope with snake cased field names

Once these changes are merged, we should be unblocked to generate Go types
from the cue schema and hopefully, also generate documentation from the
comments within the schema.