### PR TITLE
ci: lint cue schema changes in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4.2.2
+      - name: Setup Cue
+        uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
+      - name: Validate the layer 2 schema
+        run: make lintcue
       - uses: actions/setup-go@v5.4.0
         with:
           go-version: "^1.23.4"
@@ -31,8 +35,7 @@ jobs:
 
       - name: Unit tests
         run: |
-          go test ./... -coverprofile coverage.out -covermode count
-          go tool cover -func coverage.out
+          make test-cov
 
       - name: Quality Gate - Test coverage shall be above threshold
         env:
@@ -52,6 +55,4 @@ jobs:
 
       - name: Ensure build is functional
         run: |
-          cd pkg
-          cd layer2 && go build ./...
-          cd ../layer4 && go build ./...
+          make build

--- a/Makefile
+++ b/Makefile
@@ -62,3 +62,10 @@ release-mac:
 todo:
 	@read -p "Write your todo here: " TODO; \
 	echo "- [ ] $$TODO" >> TODO.md
+
+lintcue:
+	@echo "  >  Linting CUE files ..."
+	@echo "  >  Linting layer-2.cue ..."
+	@cue eval ./schemas/layer-2.cue --all-errors --verbose
+	@echo "  >  Linting layer-4.cue ..."
+	@cue eval ./schemas/layer-4.cue --all-errors --verbose

--- a/schemas/layer-2.cue
+++ b/schemas/layer-2.cue
@@ -1,3 +1,4 @@
+package layer2
 // Top level schema //
 
 catalog: {

--- a/schemas/layer-4.cue
+++ b/schemas/layer-4.cue
@@ -1,4 +1,8 @@
+package layer4
 // Top level schema //
+
+#EvaluationPlan: {
+}
 
 "evaluation-plans": [...#EvaluationPlan]
 
@@ -19,7 +23,7 @@
     name: string
     description: string
     message: string
-    "function-address" string
+    "function-address": string
     change?: #Change
     value?: _
 }


### PR DESCRIPTION
This PR changes the CI workflow to run
`cue eval...` against each schema we maintain.

The command will exit with non zero status if any
of the cue schema files are invalid.

This PR changes the schema as the eval-based
validation revealed errors in the existing files.

This closes #26 