### PR TITLE
docs: improve docs and add doc refs to insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,11 @@ Install the go module with `go get github.com/revanite-io/sci` and consult our [
 
 Use the schemas directly with [cue](https://cuelang.org/) for validating SCI data payloads against the schemas and more.
 
+Reference these example Layer 2 YAML control catalogs, to better understand how the schema can be applied.
+
+- [FINOS Common Cloud Controls](pkg/layer2/test-data/good-ccc.yaml)
+- [Open Source Project Security Baseline](pkg/layer2/test-data/good-osps.yml)
+
 ## Contributing
 
 We're so glad you asked - see [CONTRIBUTING.md](/CONTRIBUTING.md) and if you have any questions or feedback head over to the OpenSSF Slack in [#wg-orbit](https://openssf.slack.com/archives/C08NJTFAL74)
@@ -121,5 +126,5 @@ The SCI Model is intended to be used in conjunction with tooling that can help a
 
 Examples of such tools include:
 
-* [revanite-io/pvtr-github-repo](https://github.com/revanite-io/pvtr-github-repo) - this tool automates layer 4 evaluation of the [Open Source Project Security Baseline](https://baseline.openssf.org/) control catalog
-* [FINOS Common Cloud Controls](https://www.finos.org/common-cloud-controls-project) - the control catalog is modeled using the layer 2 schema and consumed using the layer 2 go package.
+- [revanite-io/pvtr-github-repo](https://github.com/revanite-io/pvtr-github-repo) - this tool automates layer 4 evaluation of the [Open Source Project Security Baseline](https://baseline.openssf.org/) control catalog
+- [FINOS Common Cloud Controls](https://www.finos.org/common-cloud-controls-project) - the control catalog is modeled using the layer 2 schema and consumed using the layer 2 go package.

--- a/security-insights.yml
+++ b/security-insights.yml
@@ -14,6 +14,10 @@ project:
     - name: Jason Meridth
       affiliation: GitHub
       email: jmeridth@gmail.com
+  documentation:
+    detailed-guide: https://pkg.go.dev/github.com/revanite-io/sci
+    quickstart-guide: https://github.com/revanite-io/sci/blob/main/README.md#usage
+    code-of-conduct: https://github.com/revanite-io/sci?tab=coc-ov-file#readme
   repositories:
     - name: sci
       url: https://github.com/revanite-io/sci
@@ -39,6 +43,8 @@ repository:
     - name: Alex Speasmaker
       affiliation: USAA
       email: alex.speasmaker@gmail.com
+  documentation:
+    contributing-guide: https://github.com/revanite-io/sci/blob/main/CONTRIBUTING.md
   license:
     url: https://github.com/revanite-io/sci?tab=Apache-2.0-1-ov-file#readme
     expression: Apache-2.0


### PR DESCRIPTION
When assessing this project against the baseline using pvtr-github-repo, it noted that our insights file was missing some important documentation detail.

This PR updates the insights data to specify the locations of docs on key topics.

This change updates https://github.com/revanite-io/sci/issues/36