### PR TITLE
chore: improved logging for layer2.Load

### DIFF
--- a/layer2/loaders.go
+++ b/layer2/loaders.go
@@ -51,7 +51,7 @@ func loadYaml(sourcePath string, data *Catalog) error {
 
 	err = decode(file, data)
 	if err != nil {
-		return fmt.Errorf("error decoding YAML: %w", err)
+		return fmt.Errorf("error decoding YAML: %w (%s)", err, sourcePath)
 	}
 	return nil
 }


### PR DESCRIPTION
As a developer user, I often load multiple files at once using SCI. When I get a load error, I would like to know which file caused the error.