### PR TITLE
chore: replace use of gopkg.in/yaml.v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,13 @@ go 1.23.0
 
 toolchain go1.24.1
 
-require gopkg.in/yaml.v3 v3.0.1
+require (
+	github.com/goccy/go-yaml v1.17.1
+	github.com/stretchr/testify v1.10.0
+)
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/stretchr/testify v1.10.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/goccy/go-yaml v1.17.1 h1:LI34wktB2xEE3ONG/2Ar54+/HJVBriAGJ55PHls4YuY=
+github.com/goccy/go-yaml v1.17.1/go.mod h1:XBurs7gK8ATbW4ZPGKgcbrY1Br56PdM69F7LkFRi1kA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/layer2/loaders.go
+++ b/layer2/loaders.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"gopkg.in/yaml.v3"
+	"github.com/goccy/go-yaml"
 )
 
 // loadYamlFromURL is a sub-function of loadYaml for HTTP only
@@ -101,8 +101,7 @@ func (c *Catalog) LoadFile(sourcePath string) error {
 }
 
 func decode(reader io.Reader, data *Catalog) error {
-	decoder := yaml.NewDecoder(reader)
-	decoder.KnownFields(true)
+	decoder := yaml.NewDecoder(reader, yaml.DisallowUnknownField())
 	err := decoder.Decode(data)
 	if err != nil {
 		return fmt.Errorf("error decoding YAML: %w", err)


### PR DESCRIPTION
This PR closes https://github.com/revanite-io/sci/issues/37 by moving our dependency to github.com/goccy/go-yaml