### PR TITLE
ci: lint our security-insights.yml in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
           version: "v0.13.0-alpha.4"
       - name: Validate the layer 2 schema
         run: make lintcue
+      - name: Validate the security-insights file
+        run: make lintinsights
       - name: Generate go types from cue schema
         run: make cuegen
       - name: Check for missing generated artifacts

--- a/Makefile
+++ b/Makefile
@@ -86,4 +86,11 @@ dirtycheck:
 		echo "  >  No uncommitted changes to generated files found."; \
 	fi
 
+lintinsights:
+	@echo "  >  Linting security-insights.yml ..."
+	@curl -O --silent https://raw.githubusercontent.com/ossf/security-insights-spec/refs/tags/v2.1.0/schema.cue
+	@cue vet security-insights.yml schema.cue
+	@rm schema.cue
+	@echo "  >  Linting security-insights.yml complete."
+
 PHONY: lintcue cuegen dirtycheck

--- a/security-insights.yml
+++ b/security-insights.yml
@@ -14,6 +14,7 @@ project:
     - name: Jason Meridth
       affiliation: GitHub
       email: jmeridth@gmail.com
+      primary: false
   documentation:
     detailed-guide: https://pkg.go.dev/github.com/revanite-io/sci
     quickstart-guide: https://github.com/revanite-io/sci/blob/main/README.md#usage
@@ -21,6 +22,9 @@ project:
   repositories:
     - name: sci
       url: https://github.com/revanite-io/sci
+      comment: |
+        The main repository for the Simplified Compliance Infrastructure (SCI) project.
+        It contains the core codebase and documentation for the project.
   vulnerability-reporting:
     reports-accepted: false
     bug-bounty-available: false
@@ -34,15 +38,19 @@ repository:
     - name: Eddie Knight
       affiliation: Sonatype
       email: knight@linux.com
+      primary: true
     - name: Jason Meridth
       affiliation: GitHub
       email: jmeridth@gmail.com
+      primary: false
     - name: Travis Truman
       affiliation: Independent
       email: trumant@gmail.com
+      primary: false
     - name: Alex Speasmaker
       affiliation: USAA
       email: alex.speasmaker@gmail.com
+      primary: false
   documentation:
     contributing-guide: https://github.com/revanite-io/sci/blob/main/CONTRIBUTING.md
   license:


### PR DESCRIPTION
Inspired by the work in https://github.com/revanite-io/sci/pull/55

I realized as I was reviewing that PR, that I really want the CI workflow to give me basic validation feedback before spending time on my review.

Which led me here, only to find and then fix a bunch of validation issues.