### PR TITLE
revert: layer2.Layer2 should be layer2.Catalog

### DIFF
--- a/layer2/generated_types.go
+++ b/layer2/generated_types.go
@@ -2,7 +2,7 @@
 
 package layer2
 
-type Layer2 struct {
+type Catalog struct {
 	Metadata *Metadata `json:"metadata,omitempty"`
 
 	ControlFamilies []ControlFamily `json:"control-families,omitempty"`

--- a/layer2/loaders.go
+++ b/layer2/loaders.go
@@ -12,7 +12,7 @@ import (
 
 // loadYamlFromURL is a sub-function of loadYaml for HTTP only
 // sourcePath is the URL. data is a pointer to the recieving object.
-func loadYamlFromURL(sourcePath string, data *Layer2) error {
+func loadYamlFromURL(sourcePath string, data *Catalog) error {
 	resp, err := http.Get(sourcePath)
 	if err != nil {
 		return fmt.Errorf("failed to fetch URL: %v", err)
@@ -35,7 +35,7 @@ func loadYamlFromURL(sourcePath string, data *Layer2) error {
 // loadYaml opens a provided path to unmarshal its data as YAML.
 // sourcePath is a URL or local path to a file.
 // data is a pointer to the recieving object.
-func loadYaml(sourcePath string, data *Layer2) error {
+func loadYaml(sourcePath string, data *Catalog) error {
 	if strings.HasPrefix(sourcePath, "http") {
 		return loadYamlFromURL(sourcePath, data)
 	}
@@ -59,16 +59,16 @@ func loadYaml(sourcePath string, data *Layer2) error {
 // loadYaml opens a provided path to unmarshal its data as JSON.
 // sourcePath is a URL or local path to a file.
 // data is a pointer to the recieving object.
-func loadJson(sourcePath string, data *Layer2) error {
+func loadJson(sourcePath string, data *Catalog) error {
 	return fmt.Errorf("loadJson not implemented [%s, %v]", sourcePath, data)
 }
 
 // LoadControlFamiliesFile loads data from any number of YAML
 // files at the provided paths. JSON support is pending development.
 // If run multiple times, this method will append new data to previous data.
-func (c *Layer2) LoadFiles(sourcePaths []string) error {
+func (c *Catalog) LoadFiles(sourcePaths []string) error {
 	for _, sourcePath := range sourcePaths {
-		catalog := &Layer2{}
+		catalog := &Catalog{}
 		err := c.LoadFile(sourcePath)
 		if err != nil {
 			return err
@@ -83,7 +83,7 @@ func (c *Layer2) LoadFiles(sourcePaths []string) error {
 // LoadControlFamiliesFile loads data from a single YAML
 // file at the provided path. JSON support is pending development.
 // If run multiple times for the same data type, this method will override previous data.
-func (c *Layer2) LoadFile(sourcePath string) error {
+func (c *Catalog) LoadFile(sourcePath string) error {
 	if strings.Contains(sourcePath, ".yaml") || strings.Contains(sourcePath, ".yml") {
 		err := loadYaml(sourcePath, c)
 		if err != nil {
@@ -100,7 +100,7 @@ func (c *Layer2) LoadFile(sourcePath string) error {
 	return nil
 }
 
-func decode(reader io.Reader, data *Layer2) error {
+func decode(reader io.Reader, data *Catalog) error {
 	decoder := yaml.NewDecoder(reader, yaml.DisallowUnknownField())
 	err := decoder.Decode(data)
 	if err != nil {

--- a/layer2/loaders_test.go
+++ b/layer2/loaders_test.go
@@ -48,7 +48,7 @@ var tests = []struct {
 func Test_loadYaml(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data := &Layer2{}
+			data := &Catalog{}
 			if err := loadYaml(tt.sourcePath, data); (err == nil) == tt.wantErr {
 				t.Errorf("loadYaml() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -59,7 +59,7 @@ func Test_loadYaml(t *testing.T) {
 func Test_LoadFile(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Layer2{}
+			c := &Catalog{}
 			err := c.LoadFile(tt.sourcePath)
 			if (err == nil) == tt.wantErr {
 				t.Errorf("Catalog.LoadControlFamily() error = %v, wantErr %v", err, tt.wantErr)
@@ -77,13 +77,13 @@ func Test_LoadFile(t *testing.T) {
 func Test_LoadFiles(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Layer2{}
+			c := &Catalog{}
 			err := c.LoadFiles([]string{tt.sourcePath})
 			if (err == nil) == tt.wantErr {
-				t.Errorf("Layer2.LoadControlFamilyFiles() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Catalog.LoadControlFamilyFiles() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if !tt.wantErr && len(c.ControlFamilies) == 0 {
-				t.Errorf("Layer2.LoadControlFamilyFiles() did not load any control families")
+				t.Errorf("Catalog.LoadControlFamilyFiles() did not load any control families")
 			}
 		})
 	}
@@ -117,7 +117,7 @@ func Test_loadYamlFromURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data := &Layer2{}
+			data := &Catalog{}
 			err := loadYamlFromURL(tt.sourcePath, data)
 			if err != nil && tt.wantErr {
 				assert.Containsf(t, err.Error(), tt.errorExpected, "expected error containing %q, got %s", tt.errorExpected, err)
@@ -148,7 +148,7 @@ func Test_loadJson(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data := &Layer2{}
+			data := &Catalog{}
 			err := loadJson(tt.sourcePath, data)
 			if (err == nil) == tt.wantErr {
 				t.Errorf("loadJson() error = %v, wantErr %v", err, tt.wantErr)
@@ -172,7 +172,7 @@ func Test_LoadFile_UnsupportedFileType(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			c := &Layer2{}
+			c := &Catalog{}
 			err := c.LoadFile(tt.sourcePath)
 			if (err == nil) == tt.wantErr {
 				t.Errorf("Catalog.LoadFile() error = %v, wantErr %v", err, tt.wantErr)

--- a/schemas/layer-2.cue
+++ b/schemas/layer-2.cue
@@ -1,7 +1,7 @@
 package schemas
 @go(layer2)
 
-#Layer2: {
+#Catalog: {
     metadata?: #Metadata
 
     "control-families"?: [...#ControlFamily] @go(ControlFamilies)


### PR DESCRIPTION
Previously layer2 was used like this:

```go
import (
	"github.com/revanite-io/sci/pkg/layer2"
)

func loadData() (output []availableCapability) {
	var catalog layer2.Catalog
        // omitted
}
```

but as of `v0.3.5` the usage is this:

```go
import (
	"github.com/revanite-io/sci/layer2"
)

func loadData() (output []availableCapability) {
	var layer2 layer2.Layer2
        // omitted
}
```

As a user, I find the former naming to be clear and helpful. This PR reverts the associated change.