### PR TITLE
ci: add a composite GH Action for SI linting

### DIFF
--- a/.github/actions/lint-insights/action.yaml
+++ b/.github/actions/lint-insights/action.yaml
@@ -26,7 +26,7 @@ runs:
     - name: Lint security-insights.yml
       run: |
         echo "::group::Linting security-insights.yml ..."
-        ROOT="${GITHUB_ACTION_PATH}/../.."
+        ROOT="${GITHUB_ACTION_PATH}/../../.."
         make lintinsights -f "${ROOT}/Makefile"
         echo "::endgroup::"
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Validate the security-insights file
         uses: ./actions/lint-insights
         with:
-          cue_setup: 'false'
+          cue_setup: "false"
       - name: Generate go types from cue schema
         run: make cuegen
       - name: Check for missing generated artifacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Validate the layer 2 schema
         run: make lintcue
       - name: Validate the security-insights file
-        uses: ./actions/lint-insights
+        uses: ./.github/actions/lint-insights
         with:
           cue_setup: "false"
       - name: Generate go types from cue schema

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Validate the layer 2 schema
         run: make lintcue
       - name: Validate the security-insights file
-        run: make lintinsights
+        uses: ./actions/lint-insights
+        with:
+          cue_setup: 'false'
       - name: Generate go types from cue schema
         run: make cuegen
       - name: Check for missing generated artifacts

--- a/Makefile
+++ b/Makefile
@@ -86,10 +86,12 @@ dirtycheck:
 		echo "  >  No uncommitted changes to generated files found."; \
 	fi
 
+VERSION ?= "v2.1.0"
+SI_PATH ?= "security-insights.yml"
 lintinsights:
-	@echo "  >  Linting security-insights.yml ..."
-	@curl -O --silent https://raw.githubusercontent.com/ossf/security-insights-spec/refs/tags/v2.1.0/schema.cue
-	@cue vet security-insights.yml schema.cue
+	@echo "  >  Linting security-insights.yml..."
+	@curl -O --silent "https://raw.githubusercontent.com/ossf/security-insights-spec/refs/tags/$(VERSION)/schema.cue"
+	@cue vet -d '#SecurityInsights' "$(SI_PATH)" schema.cue
 	@rm schema.cue
 	@echo "  >  Linting security-insights.yml complete."
 

--- a/actions/lint-insights/action.yaml
+++ b/actions/lint-insights/action.yaml
@@ -1,0 +1,36 @@
+name: 'Lint Security Insights File'
+description: 'Use cue to validate a given security insights file against the SI schema.'
+
+inputs:
+  si_path:
+    description: 'Relative security-insights.yml path'
+    required: false
+    default: 'security-insights.yml'
+  schema_version:
+    description: 'Version of the SI schema to use'
+    required: false
+    default: 'v2.1.0'
+  cue_setup:
+    description: 'Run setup-cue (defaults to true)'
+    required: false
+    default: true
+
+runs:
+  using: "composite"
+  steps:
+    - if: inputs.cue_setup == 'true'
+      uses: cue-lang/setup-cue@a93fa358375740cd8b0078f76355512b9208acb1 # v1.0.1
+      with:
+        version: "v0.13.0-alpha.4"
+
+    - name: Lint security-insights.yml
+      run: |
+        echo "::group::Linting security-insights.yml ..."
+        curl -O --silent "https://raw.githubusercontent.com/ossf/security-insights-spec/refs/tags/${VERSION}/schema.cue"
+        cue vet -d '#SecurityInsights' "${SI_PATH}" schema.cue
+        rm schema.cue
+        echo "::endgroup::"
+      env:
+        VERSION: ${{ inputs.schema_version }}
+        SI_PATH: ${{ inputs.si_path }}
+      shell: bash

--- a/actions/lint-insights/action.yaml
+++ b/actions/lint-insights/action.yaml
@@ -13,7 +13,7 @@ inputs:
   cue_setup:
     description: 'Run setup-cue (defaults to true)'
     required: false
-    default: true
+    default: "true"
 
 runs:
   using: "composite"

--- a/actions/lint-insights/action.yaml
+++ b/actions/lint-insights/action.yaml
@@ -26,9 +26,8 @@ runs:
     - name: Lint security-insights.yml
       run: |
         echo "::group::Linting security-insights.yml ..."
-        curl -O --silent "https://raw.githubusercontent.com/ossf/security-insights-spec/refs/tags/${VERSION}/schema.cue"
-        cue vet -d '#SecurityInsights' "${SI_PATH}" schema.cue
-        rm schema.cue
+        ROOT="${GITHUB_ACTION_PATH}/../.."
+        make lintinsights -f "${ROOT}/Makefile"
         echo "::endgroup::"
       env:
         VERSION: ${{ inputs.schema_version }}


### PR DESCRIPTION
Add a top level `actions` directory with a composite action for linting the security insights file.

A couple points which could be up for discussion:
- Adds cue setup as an opt-out step because I figured those consuming this likely will not have this dependency installed
- `actions` is in the root of the repository rather that `.github/actions` for discoverabilty 

Closes #62 

