### PR TITLE
feat!: adds `EvaluationPlan` to layer 4 schema

### DIFF
--- a/layer4/assessment_log_test.go
+++ b/layer4/assessment_log_test.go
@@ -6,45 +6,45 @@ import (
 
 func getAssessmentsTestData() []struct {
 	testName           string
-	assessment         Assessment
+	assessment         AssessmentLog
 	numberOfSteps      int
 	numberOfStepsToRun int
 	expectedResult     Result
 } {
 	return []struct {
 		testName           string
-		assessment         Assessment
+		assessment         AssessmentLog
 		numberOfSteps      int
 		numberOfStepsToRun int
 		expectedResult     Result
 	}{
 		{
-			testName:   "Assessment with no steps",
-			assessment: Assessment{},
+			testName:   "AssessmentLog with no steps",
+			assessment: AssessmentLog{},
 		},
 		{
-			testName:           "Assessment with one step",
+			testName:           "AssessmentLog with one step",
 			assessment:         passingAssessment(),
 			numberOfSteps:      1,
 			numberOfStepsToRun: 1,
 			expectedResult:     Passed,
 		},
 		{
-			testName:           "Assessment with two steps",
+			testName:           "AssessmentLog with two steps",
 			assessment:         failingAssessment(),
 			numberOfSteps:      2,
 			numberOfStepsToRun: 1,
 			expectedResult:     Failed,
 		},
 		{
-			testName:           "Assessment with three steps",
+			testName:           "AssessmentLog with three steps",
 			assessment:         needsReviewAssessment(),
 			numberOfSteps:      3,
 			numberOfStepsToRun: 3,
 			expectedResult:     NeedsReview,
 		},
 		{
-			testName:           "Assessment with four steps",
+			testName:           "AssessmentLog with four steps",
 			assessment:         badRevertPassingAssessment(),
 			numberOfSteps:      4,
 			numberOfStepsToRun: 4,
@@ -53,7 +53,7 @@ func getAssessmentsTestData() []struct {
 	}
 }
 
-// TestNewStep ensures that NewStep queues a new step in the Assessment
+// TestNewStep ensures that NewStep queues a new step in the AssessmentLog
 func TestAddStep(t *testing.T) {
 	for _, test := range getAssessmentsTestData() {
 		t.Run(test.testName, func(t *testing.T) {
@@ -68,7 +68,7 @@ func TestAddStep(t *testing.T) {
 	}
 }
 
-// TestRunStep ensures that runStep runs the step and updates the Assessment
+// TestRunStep ensures that runStep runs the step and updates the AssessmentLog
 func TestRunStep(t *testing.T) {
 	stepsTestData := []struct {
 		testName string
@@ -98,7 +98,7 @@ func TestRunStep(t *testing.T) {
 	}
 	for _, test := range stepsTestData {
 		t.Run(test.testName, func(t *testing.T) {
-			anyOldAssessment := Assessment{}
+			anyOldAssessment := AssessmentLog{}
 			result := anyOldAssessment.runStep(nil, test.step)
 			if result != test.result {
 				t.Errorf("expected %s, got %s", test.result, result)
@@ -147,9 +147,9 @@ func TestRunB(t *testing.T) {
 	}
 }
 
-// TestNewChange ensures that NewChange creates a new Change object and adds it to the Assessment
+// TestNewChange ensures that NewChange creates a new Change object and adds it to the AssessmentLog
 func TestNewChange(t *testing.T) {
-	anyOldAssessment := Assessment{}
+	anyOldAssessment := AssessmentLog{}
 	testName := "Add-a-new-change"
 	t.Run(testName, func(t *testing.T) {
 		if len(anyOldAssessment.Changes) != 0 {
@@ -169,41 +169,41 @@ func TestNewChange(t *testing.T) {
 	})
 }
 
-// TestRevertChanges ensures that RevertChanges attempts to revert all changes in the Assessment
+// TestRevertChanges ensures that RevertChanges attempts to revert all changes in the AssessmentLog
 func TestRevertChanges(t *testing.T) {
 	revertChangesTestData := []struct {
 		testName   string
-		assessment Assessment
+		assessment AssessmentLog
 		corrupted  bool
 	}{
 		{
 			testName:   "No changes",
-			assessment: Assessment{},
+			assessment: AssessmentLog{},
 			corrupted:  false,
 		},
 		{
 			testName:   "Change already applied and reverted",
-			assessment: Assessment{Changes: map[string]*Change{"test": goodRevertedChangePtr()}},
+			assessment: AssessmentLog{Changes: map[string]*Change{"test": goodRevertedChangePtr()}},
 			corrupted:  false,
 		},
 		{
 			testName:   "Change without apply function",
-			assessment: Assessment{Changes: map[string]*Change{"test": noApplyChangePtr()}},
+			assessment: AssessmentLog{Changes: map[string]*Change{"test": noApplyChangePtr()}},
 			corrupted:  true,
 		},
 		{
 			testName:   "Change with error from apply function",
-			assessment: Assessment{Changes: map[string]*Change{"test": badApplyChangePtr()}},
+			assessment: AssessmentLog{Changes: map[string]*Change{"test": badApplyChangePtr()}},
 			corrupted:  true,
 		},
 		{
 			testName:   "Change with error from revert function",
-			assessment: Assessment{Changes: map[string]*Change{"test": badRevertChangePtr()}},
+			assessment: AssessmentLog{Changes: map[string]*Change{"test": badRevertChangePtr()}},
 			corrupted:  true,
 		},
 		{
 			testName:   "Change previously applied and needs reverted",
-			assessment: Assessment{Changes: map[string]*Change{"test": goodNotRevertedChangePtr()}},
+			assessment: AssessmentLog{Changes: map[string]*Change{"test": goodNotRevertedChangePtr()}},
 			corrupted:  false,
 		},
 		{

--- a/layer4/control_evaluation_test.go
+++ b/layer4/control_evaluation_test.go
@@ -10,85 +10,85 @@ var controlEvaluationTestData = []struct {
 	expectedCorrupted bool
 }{
 	{
-		testName:          "ControlEvaluation with no Assessments",
+		testName:          "ControlEvaluation with no AssessmentLogs",
 		expectedResult:    NeedsReview,
 		expectedCorrupted: false,
 		control: &ControlEvaluation{
-			Assessments: []*Assessment{},
+			AssessmentLogs: []*AssessmentLog{},
 		},
 	},
 	{
-		testName:          "ControlEvaluation with one passing Assessment",
+		testName:          "ControlEvaluation with one passing AssessmentLog",
 		expectedResult:    Passed,
 		expectedCorrupted: false,
 		control: &ControlEvaluation{
-			Assessments: []*Assessment{passingAssessmentPtr()},
+			AssessmentLogs: []*AssessmentLog{passingAssessmentPtr()},
 		},
 	},
 	{
-		testName:          "ControlEvaluation with one failing Assessment",
+		testName:          "ControlEvaluation with one failing AssessmentLog",
 		expectedResult:    Failed,
 		expectedCorrupted: false,
 		control: &ControlEvaluation{
-			Assessments: []*Assessment{failingAssessmentPtr()},
+			AssessmentLogs: []*AssessmentLog{failingAssessmentPtr()},
 		},
 	},
 	{
-		testName:          "ControlEvaluation with one NeedsReview Assessment",
+		testName:          "ControlEvaluation with one NeedsReview AssessmentLog",
 		expectedResult:    NeedsReview,
 		expectedCorrupted: false,
 		control: &ControlEvaluation{
-			Assessments: []*Assessment{needsReviewAssessmentPtr()},
+			AssessmentLogs: []*AssessmentLog{needsReviewAssessmentPtr()},
 		},
 	},
 	{
-		testName:          "ControlEvaluation with one Unknown Assessment",
+		testName:          "ControlEvaluation with one Unknown AssessmentLog",
 		expectedResult:    Unknown,
 		expectedCorrupted: false,
 		control: &ControlEvaluation{
-			Assessments: []*Assessment{unknownAssessmentPtr()},
+			AssessmentLogs: []*AssessmentLog{unknownAssessmentPtr()},
 		},
 	},
 	{
-		testName:          "ControlEvaluation with first NeedsReview and then Unknown Assessment",
+		testName:          "ControlEvaluation with first NeedsReview and then Unknown AssessmentLog",
 		expectedResult:    Unknown,
 		expectedCorrupted: false,
 		control: &ControlEvaluation{
-			Assessments: []*Assessment{
+			AssessmentLogs: []*AssessmentLog{
 				needsReviewAssessmentPtr(),
 				unknownAssessmentPtr(),
 			},
 		},
 	},
 	{
-		testName:          "ControlEvaluation with first Unknown and then NeedsReview Assessment",
+		testName:          "ControlEvaluation with first Unknown and then NeedsReview AssessmentLog",
 		expectedResult:    Unknown,
 		expectedCorrupted: false,
 		control: &ControlEvaluation{
-			Assessments: []*Assessment{
+			AssessmentLogs: []*AssessmentLog{
 				unknownAssessmentPtr(),
 				needsReviewAssessmentPtr(),
 			},
 		},
 	},
 	{
-		testName:          "ControlEvaluation with first Failed and then NeedsReview Assessment",
+		testName:          "ControlEvaluation with first Failed and then NeedsReview AssessmentLog",
 		expectedResult:    Failed,
 		expectedCorrupted: false,
 		control: &ControlEvaluation{
-			Assessments: []*Assessment{
+			AssessmentLogs: []*AssessmentLog{
 				failingAssessmentPtr(),
 				needsReviewAssessmentPtr(),
 			},
 		},
 	},
 	{
-		testName:          "ControlEvaluation with first Failing and then Passing Assessment",
+		testName:          "ControlEvaluation with first Failing and then Passing AssessmentLog",
 		expectedResult:    Failed,
 		failBeforePass:    true,
 		expectedCorrupted: false,
 		control: &ControlEvaluation{
-			Assessments: []*Assessment{
+			AssessmentLogs: []*AssessmentLog{
 				failingAssessmentPtr(),
 				passingAssessmentPtr(),
 			},
@@ -115,7 +115,7 @@ func TestEvaluate(t *testing.T) {
 			c := test.control // copy the control to avoid duplication in the next test
 			c.Evaluate(nil, testingApplicability, false)
 
-			for _, assessment := range c.Assessments {
+			for _, assessment := range c.AssessmentLogs {
 				if assessment.Changes != nil {
 					for _, change := range assessment.Changes {
 						if change.Applied {
@@ -145,8 +145,8 @@ func TestAddAssesment(t *testing.T) {
 		t.Errorf("Expected Result to be Failed, but it was %v", controlEvaluationTestData[0].control.Result)
 	}
 
-	if controlEvaluationTestData[0].control.Message != "expected all Assessment fields to have a value, but got: requirementId=len(4), description=len=(4), applicability=len(0), steps=len(0)" {
-		t.Errorf("Expected error message to be 'expected all Assessment fields to have a value, but got: requirementId=len(4), description=len=(4), applicability=len(0), steps=len(0)', but instead it was '%v'", controlEvaluationTestData[0].control.Message)
+	if controlEvaluationTestData[0].control.Message != "expected all AssessmentLog fields to have a value, but got: requirementId=len(4), description=len=(4), applicability=len(0), steps=len(0)" {
+		t.Errorf("Expected error message to be 'expected all AssessmentLog fields to have a value, but got: requirementId=len(4), description=len=(4), applicability=len(0), steps=len(0)', but instead it was '%v'", controlEvaluationTestData[0].control.Message)
 	}
 
 }

--- a/layer4/evaluation_plan.go
+++ b/layer4/evaluation_plan.go
@@ -1,63 +1,63 @@
 package layer4
 
 type EvaluationPlan struct {
-	Metadata Metadata `json:"metadata"`
+	Metadata	Metadata	`json:"metadata" yaml:"metadata"`
 
-	Plans []AssessmentPlan `json:"plans"`
+	Plans	[]AssessmentPlan	`json:"plans" yaml:"plans"`
 }
 
 type Metadata struct {
-	Id string `json:"id"`
+	Id	string	`json:"id" yaml:"id"`
 
-	Version string `json:"version,omitempty"`
+	Version	string	`json:"version,omitempty" yaml:"version,omitempty"`
 
-	Author Contact `json:"author"`
+	Author	Contact	`json:"author" yaml:"author"`
 }
 
 type Contact struct {
 	// The contact person's name.
-	Name string `json:"name"`
+	Name	string	`json:"name" yaml:"name"`
 
 	// Indicates whether this admin is the first point of contact for inquiries. Only one entry should be marked as primary.
-	Primary bool `json:"primary"`
+	Primary	bool	`json:"primary" yaml:"primary"`
 
 	// The entity with which the contact is affiliated, such as a school or employer.
-	Affiliation *string `json:"affiliation,omitempty"`
+	Affiliation	*string	`json:"affiliation,omitempty" yaml:"affiliation,omitempty"`
 
 	// A preferred email address to reach the contact.
-	Email *string `json:"email,omitempty"`
+	Email	*string	`json:"email,omitempty" yaml:"email,omitempty"`
 
 	// A social media handle or profile for the contact.
-	Social *string `json:"social,omitempty"`
+	Social	*string	`json:"social,omitempty" yaml:"social,omitempty"`
 }
 
 // AssessmentPlan defines all testing procedures for a control id.
 type AssessmentPlan struct {
-	ControlId string `json:"control-id"`
+	ControlId	string	`json:"control-id" yaml:"control-id"`
 
-	Assessments []Assessment `json:"assessments"`
+	Assessments	[]Assessment	`json:"assessments" yaml:"assessments"`
 }
 
 // AssessmentPlan defines all testing procedures for a requirement.
 type Assessment struct {
 	// RequirementID is the unique identifier for the requirement being tested
-	RequirementId string `json:"requirement-id"`
+	RequirementId	string	`json:"requirement-id" yaml:"requirement-id"`
 
 	// Procedures defined possible testing procedures to evaluate the requirement.
-	Procedures []AssessmentProcedure `json:"procedures"`
+	Procedures	[]AssessmentProcedure	`json:"procedures" yaml:"procedures"`
 }
 
 // AssessmentProcedure describes a testing procedure for evaluating a Layer 2 control requirement.
 type AssessmentProcedure struct {
 	// Id uniquely identifies the assessment procedure being executed
-	Id string `json:"id"`
+	Id	string	`json:"id" yaml:"id"`
 
 	// Name provides a summary of the procedure
-	Name string `json:"name"`
+	Name	string	`json:"name" yaml:"name"`
 
 	// Description provides a detailed explanation of the procedure
-	Description string `json:"description"`
+	Description	string	`json:"description" yaml:"description"`
 
 	// Documentation provides a URL to documentation that describes how the assessment procedure evaluates the control requirement
-	Documentation string `json:"documentation,omitempty"`
+	Documentation	string	`json:"documentation,omitempty" yaml:"documentation,omitempty"`
 }

--- a/layer4/evaluation_plan.go
+++ b/layer4/evaluation_plan.go
@@ -1,63 +1,65 @@
 package layer4
 
+// EvaluationPlan defines how a set of Layer 4 controls are to be evaluated.
 type EvaluationPlan struct {
-	Metadata Metadata `json:"metadata" yaml:"metadata"`
+	Metadata	Metadata	`json:"metadata" yaml:"metadata"`
 
-	Plans []AssessmentPlan `json:"plans" yaml:"plans"`
+	Plans	[]AssessmentPlan	`json:"plans" yaml:"plans"`
 }
 
+// Metadata contains metadata about the evaluation plan.
 type Metadata struct {
-	Id string `json:"id" yaml:"id"`
+	Id	string	`json:"id" yaml:"id"`
 
-	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+	Version	string	`json:"version,omitempty" yaml:"version,omitempty"`
 
-	Author Contact `json:"author" yaml:"author"`
+	Author	Contact	`json:"author" yaml:"author"`
 }
 
 type Contact struct {
 	// The contact person's name.
-	Name string `json:"name" yaml:"name"`
+	Name	string	`json:"name" yaml:"name"`
 
 	// Indicates whether this admin is the first point of contact for inquiries. Only one entry should be marked as primary.
-	Primary bool `json:"primary" yaml:"primary"`
+	Primary	bool	`json:"primary" yaml:"primary"`
 
 	// The entity with which the contact is affiliated, such as a school or employer.
-	Affiliation *string `json:"affiliation,omitempty" yaml:"affiliation,omitempty"`
+	Affiliation	*string	`json:"affiliation,omitempty" yaml:"affiliation,omitempty"`
 
 	// A preferred email address to reach the contact.
-	Email *string `json:"email,omitempty" yaml:"email,omitempty"`
+	Email	*string	`json:"email,omitempty" yaml:"email,omitempty"`
 
 	// A social media handle or profile for the contact.
-	Social *string `json:"social,omitempty" yaml:"social,omitempty"`
+	Social	*string	`json:"social,omitempty" yaml:"social,omitempty"`
 }
 
 // AssessmentPlan defines all testing procedures for a control id.
 type AssessmentPlan struct {
-	ControlId string `json:"control-id" yaml:"control-id"`
+	ControlId	string	`json:"control-id" yaml:"control-id"`
 
-	Assessments []Assessment `json:"assessments" yaml:"assessments"`
+	Assessments	[]Assessment	`json:"assessments" yaml:"assessments"`
 }
 
 // Assessment defines all testing procedures for a requirement.
 type Assessment struct {
-	// RequirementID is the unique identifier for the requirement being tested.
-	RequirementId string `json:"requirement-id" yaml:"requirement-id"`
+	// RequirementId is the unique identifier for the requirement being tested.
+	RequirementId	string	`json:"requirement-id" yaml:"requirement-id"`
 
 	// Procedures defines possible testing procedures to evaluate the requirement.
-	Procedures []AssessmentProcedure `json:"procedures" yaml:"procedures"`
+	Procedures	[]AssessmentProcedure	`json:"procedures" yaml:"procedures"`
 }
 
 // AssessmentProcedure describes a testing procedure for evaluating a Layer 2 control requirement.
 type AssessmentProcedure struct {
 	// Id uniquely identifies the assessment procedure being executed
-	Id string `json:"id" yaml:"id"`
+	Id	string	`json:"id" yaml:"id"`
 
 	// Name provides a summary of the procedure
-	Name string `json:"name" yaml:"name"`
+	Name	string	`json:"name" yaml:"name"`
 
 	// Description provides a detailed explanation of the procedure
-	Description string `json:"description" yaml:"description"`
+	Description	string	`json:"description" yaml:"description"`
 
 	// Documentation provides a URL to documentation that describes how the assessment procedure evaluates the control requirement
-	Documentation string `json:"documentation,omitempty" yaml:"documentation,omitempty"`
+	Documentation	string	`json:"documentation,omitempty" yaml:"documentation,omitempty"`
 }

--- a/layer4/evaluation_plan.go
+++ b/layer4/evaluation_plan.go
@@ -1,63 +1,63 @@
 package layer4
 
 type EvaluationPlan struct {
-	Metadata	Metadata	`json:"metadata" yaml:"metadata"`
+	Metadata Metadata `json:"metadata" yaml:"metadata"`
 
-	Plans	[]AssessmentPlan	`json:"plans" yaml:"plans"`
+	Plans []AssessmentPlan `json:"plans" yaml:"plans"`
 }
 
 type Metadata struct {
-	Id	string	`json:"id" yaml:"id"`
+	Id string `json:"id" yaml:"id"`
 
-	Version	string	`json:"version,omitempty" yaml:"version,omitempty"`
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 
-	Author	Contact	`json:"author" yaml:"author"`
+	Author Contact `json:"author" yaml:"author"`
 }
 
 type Contact struct {
 	// The contact person's name.
-	Name	string	`json:"name" yaml:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Indicates whether this admin is the first point of contact for inquiries. Only one entry should be marked as primary.
-	Primary	bool	`json:"primary" yaml:"primary"`
+	Primary bool `json:"primary" yaml:"primary"`
 
 	// The entity with which the contact is affiliated, such as a school or employer.
-	Affiliation	*string	`json:"affiliation,omitempty" yaml:"affiliation,omitempty"`
+	Affiliation *string `json:"affiliation,omitempty" yaml:"affiliation,omitempty"`
 
 	// A preferred email address to reach the contact.
-	Email	*string	`json:"email,omitempty" yaml:"email,omitempty"`
+	Email *string `json:"email,omitempty" yaml:"email,omitempty"`
 
 	// A social media handle or profile for the contact.
-	Social	*string	`json:"social,omitempty" yaml:"social,omitempty"`
+	Social *string `json:"social,omitempty" yaml:"social,omitempty"`
 }
 
 // AssessmentPlan defines all testing procedures for a control id.
 type AssessmentPlan struct {
-	ControlId	string	`json:"control-id" yaml:"control-id"`
+	ControlId string `json:"control-id" yaml:"control-id"`
 
-	Assessments	[]Assessment	`json:"assessments" yaml:"assessments"`
+	Assessments []Assessment `json:"assessments" yaml:"assessments"`
 }
 
-// AssessmentPlan defines all testing procedures for a requirement.
+// Assessment defines all testing procedures for a requirement.
 type Assessment struct {
-	// RequirementID is the unique identifier for the requirement being tested
-	RequirementId	string	`json:"requirement-id" yaml:"requirement-id"`
+	// RequirementID is the unique identifier for the requirement being tested.
+	RequirementId string `json:"requirement-id" yaml:"requirement-id"`
 
-	// Procedures defined possible testing procedures to evaluate the requirement.
-	Procedures	[]AssessmentProcedure	`json:"procedures" yaml:"procedures"`
+	// Procedures defines possible testing procedures to evaluate the requirement.
+	Procedures []AssessmentProcedure `json:"procedures" yaml:"procedures"`
 }
 
 // AssessmentProcedure describes a testing procedure for evaluating a Layer 2 control requirement.
 type AssessmentProcedure struct {
 	// Id uniquely identifies the assessment procedure being executed
-	Id	string	`json:"id" yaml:"id"`
+	Id string `json:"id" yaml:"id"`
 
 	// Name provides a summary of the procedure
-	Name	string	`json:"name" yaml:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Description provides a detailed explanation of the procedure
-	Description	string	`json:"description" yaml:"description"`
+	Description string `json:"description" yaml:"description"`
 
 	// Documentation provides a URL to documentation that describes how the assessment procedure evaluates the control requirement
-	Documentation	string	`json:"documentation,omitempty" yaml:"documentation,omitempty"`
+	Documentation string `json:"documentation,omitempty" yaml:"documentation,omitempty"`
 }

--- a/layer4/evaluation_plan.go
+++ b/layer4/evaluation_plan.go
@@ -1,0 +1,63 @@
+package layer4
+
+type EvaluationPlan struct {
+	Metadata Metadata `json:"metadata"`
+
+	Plans []AssessmentPlan `json:"plans"`
+}
+
+type Metadata struct {
+	Id string `json:"id"`
+
+	Version string `json:"version,omitempty"`
+
+	Author Contact `json:"author"`
+}
+
+type Contact struct {
+	// The contact person's name.
+	Name string `json:"name"`
+
+	// Indicates whether this admin is the first point of contact for inquiries. Only one entry should be marked as primary.
+	Primary bool `json:"primary"`
+
+	// The entity with which the contact is affiliated, such as a school or employer.
+	Affiliation *string `json:"affiliation,omitempty"`
+
+	// A preferred email address to reach the contact.
+	Email *string `json:"email,omitempty"`
+
+	// A social media handle or profile for the contact.
+	Social *string `json:"social,omitempty"`
+}
+
+// AssessmentPlan defines all testing procedures for a control id.
+type AssessmentPlan struct {
+	ControlId string `json:"control-id"`
+
+	Assessments []Assessment `json:"assessments"`
+}
+
+// AssessmentPlan defines all testing procedures for a requirement.
+type Assessment struct {
+	// RequirementID is the unique identifier for the requirement being tested
+	RequirementId string `json:"requirement-id"`
+
+	// Procedures defined possible testing procedures to evaluate the requirement.
+	Procedures []AssessmentProcedure `json:"procedures"`
+}
+
+// AssessmentProcedure describes a testing procedure for evaluating a Layer 2 control requirement.
+type AssessmentProcedure struct {
+	// Id uniquely identifies the assessment procedure being executed
+	Id string `json:"id"`
+
+	// Name provides a summary of the procedure
+	Name string `json:"name"`
+
+	// Description provides a detailed explanation of the procedure
+	Description string `json:"description"`
+
+	// Documentation provides a URL to documentation that describes how the assessment procedure evaluates the control requirement
+	Documentation string `json:"documentation,omitempty"`
+}

--- a/layer4/test-data.go
+++ b/layer4/test-data.go
@@ -146,13 +146,13 @@ func disallowedChange() Change {
 	}
 }
 
-func failingAssessmentPtr() *Assessment {
+func failingAssessmentPtr() *AssessmentLog {
 	a := failingAssessment()
 	return &a
 }
 
-func failingAssessment() Assessment {
-	return Assessment{
+func failingAssessment() AssessmentLog {
+	return AssessmentLog{
 		RequirementId: "failingAssessment()",
 		Description:   "failing assessment",
 		Steps: []AssessmentStep{
@@ -162,13 +162,13 @@ func failingAssessment() Assessment {
 		Applicability: testingApplicability,
 	}
 }
-func passingAssessmentPtr() *Assessment {
+func passingAssessmentPtr() *AssessmentLog {
 	a := passingAssessment()
 	return &a
 }
 
-func passingAssessment() Assessment {
-	return Assessment{
+func passingAssessment() AssessmentLog {
+	return AssessmentLog{
 		RequirementId: "passingAssessment()",
 		Description:   "passing assessment",
 		Steps: []AssessmentStep{
@@ -180,13 +180,13 @@ func passingAssessment() Assessment {
 		},
 	}
 }
-func needsReviewAssessmentPtr() *Assessment {
+func needsReviewAssessmentPtr() *AssessmentLog {
 	a := needsReviewAssessment()
 	return &a
 }
 
-func needsReviewAssessment() Assessment {
-	return Assessment{
+func needsReviewAssessment() AssessmentLog {
+	return AssessmentLog{
 		RequirementId: "needsReviewAssessment()",
 		Description:   "needs review assessment",
 		Steps: []AssessmentStep{
@@ -197,13 +197,13 @@ func needsReviewAssessment() Assessment {
 		Applicability: testingApplicability,
 	}
 }
-func unknownAssessmentPtr() *Assessment {
+func unknownAssessmentPtr() *AssessmentLog {
 	a := unknownAssessment()
 	return &a
 }
 
-func unknownAssessment() Assessment {
-	return Assessment{
+func unknownAssessment() AssessmentLog {
+	return AssessmentLog{
 		RequirementId: "unknownAssessment()",
 		Description:   "unknown assessment",
 		Steps: []AssessmentStep{
@@ -215,8 +215,8 @@ func unknownAssessment() Assessment {
 	}
 }
 
-func badRevertPassingAssessment() Assessment {
-	return Assessment{
+func badRevertPassingAssessment() AssessmentLog {
+	return AssessmentLog{
 		RequirementId: "badRevertPassingAssessment()",
 		Description:   "bad revert passing assessment",
 		Changes: map[string]*Change{

--- a/layer4/test-data/pvtr-baseline-scan.yaml
+++ b/layer4/test-data/pvtr-baseline-scan.yaml
@@ -7,7 +7,7 @@ evaluation-set:
     result: Passed
     message: Two-factor authentication is configured as required by the parent organization
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-AC-01.01
       applicability:
       - Maturity Level 1
@@ -28,7 +28,7 @@ evaluation-set:
     result: Passed
     message: This control is enforced by GitHub for all projects
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-AC-02.01
       applicability:
       - Maturity Level 1
@@ -49,7 +49,7 @@ evaluation-set:
     result: Passed
     message: Branch protection rule prevents deletions
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-AC-03.01
       applicability:
       - Maturity Level 1
@@ -86,7 +86,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-AC-04.01
       applicability:
       - Maturity Level 2
@@ -105,7 +105,7 @@ evaluation-set:
     result: Needs Review
     message: Not implemented
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-BR-01.01
       applicability:
       - Maturity Level 1
@@ -142,7 +142,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-BR-02.01
       applicability:
       - Maturity Level 2
@@ -162,7 +162,7 @@ evaluation-set:
     result: Needs Review
     message: No official distribution points found in Security Insights data
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-BR-03.01
       applicability:
       - Maturity Level 1
@@ -199,7 +199,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-BR-04.01
       applicability:
       - Maturity Level 2
@@ -219,7 +219,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-BR-05.01
       applicability:
       - Maturity Level 2
@@ -238,7 +238,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-BR-06.01
       applicability:
       - Maturity Level 2
@@ -259,7 +259,7 @@ evaluation-set:
     result: Failed
     message: User guide was NOT specified in Security Insights data
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-DO-01.01
       applicability:
       - Maturity Level 1
@@ -281,7 +281,7 @@ evaluation-set:
     result: Failed
     message: Repository does not accept vulnerability reports
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-DO-02.01
       applicability:
       - Maturity Level 1
@@ -303,7 +303,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-DO-03.01
       applicability:
       - Maturity Level 3
@@ -323,7 +323,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-DO-04.01
       applicability:
       - Maturity Level 3
@@ -341,7 +341,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-DO-05.01
       applicability:
       - Maturity Level 3
@@ -359,7 +359,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-DO-06.01
       applicability:
       - Maturity Level 2
@@ -381,7 +381,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-GV-01.01
       applicability:
       - Maturity Level 2
@@ -416,7 +416,7 @@ evaluation-set:
     result: Passed
     message: Issues are enabled for the repository
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-GV-02.01
       applicability:
       - Maturity Level 1
@@ -437,7 +437,7 @@ evaluation-set:
     result: Needs Review
     message: "Contributing guide was found via GitHub API (Recommendation: Add code of conduct location to Security Insights data)"
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-GV-03.01
       applicability:
       - Maturity Level 1
@@ -474,7 +474,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-GV-04.01
       applicability:
       - Maturity Level 3
@@ -492,7 +492,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-LE-01.01
       applicability:
       - Maturity Level 2
@@ -511,7 +511,7 @@ evaluation-set:
     result: Needs Review
     message: All license found are OSI or FSF approved
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-LE-02.01
       applicability:
       - Maturity Level 1
@@ -533,7 +533,7 @@ evaluation-set:
     result: Passed
     message: GitHub releases include the license(s) in the released source code.
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-LE-03.01
       applicability:
       - Maturity Level 1
@@ -569,7 +569,7 @@ evaluation-set:
     result: Passed
     message: This control is enforced by GitHub for all projects
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-QA-01.01
       applicability:
       - Maturity Level 1
@@ -605,7 +605,7 @@ evaluation-set:
     result: Passed
     message: Found 8 dependency manifests from GitHub API
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-QA-02.01
       applicability:
       - Maturity Level 1
@@ -638,7 +638,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-QA-03.01
       applicability:
       - Maturity Level 2
@@ -658,7 +658,7 @@ evaluation-set:
     result: Failed
     message: Insights does NOT contains a list of repositories
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-QA-04.01
       applicability:
       - Maturity Level 1
@@ -681,7 +681,7 @@ evaluation-set:
     result: Passed
     message: No common binary file extensions were found in the repository
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-QA-05.01
       applicability:
       - Maturity Level 1
@@ -702,7 +702,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-QA-06.01
       applicability:
       - Maturity Level 2
@@ -747,7 +747,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-QA-07.01
       applicability:
       - Maturity Level 3
@@ -765,7 +765,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-SA-01.01
       applicability:
       - Maturity Level 2
@@ -784,7 +784,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-SA-02.01
       applicability:
       - Maturity Level 2
@@ -803,7 +803,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-SA-03.01
       applicability:
       - Maturity Level 2
@@ -834,7 +834,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-VM-01.01
       applicability:
       - Maturity Level 2
@@ -853,7 +853,7 @@ evaluation-set:
     result: Failed
     message: Security contacts were not specified in Security Insights data
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-VM-02.01
       applicability:
       - Maturity Level 1
@@ -872,7 +872,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-VM-03.01
       applicability:
       - Maturity Level 2
@@ -891,7 +891,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-VM-04.01
       applicability:
       - Maturity Level 2
@@ -922,7 +922,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-VM-05.01
       applicability:
       - Maturity Level 3
@@ -964,7 +964,7 @@ evaluation-set:
     result: Not Run
     message: ""
     corrupted-state: false
-    assessments:
+    assessment-logs:
     - requirement-id: OSPS-VM-06.01
       applicability:
       - Maturity Level 3

--- a/schemas/layer-4.cue
+++ b/schemas/layer-4.cue
@@ -50,7 +50,7 @@ import "time"
 #AssessmentLog: {
 	"requirement-id": string @go(RequirementId)
 	// ProcedureId uniquely identifies the assessment procedure associated with the log
-	"procedure-id"?:  string @go(ProcedureId)
+	"procedure-id"?: string @go(ProcedureId)
 	applicability: [...string]
 	description: string
 	result:      #Result
@@ -80,9 +80,9 @@ import "time"
 #Datetime: time.Format("2006-01-02T15:04:05Z07:00") @go(Datetime,format="date-time")
 
 #Metadata: {
-	id:      string
+	id:       string
 	version?: string
-	author:  #Contact
+	author:   #Contact
 }
 
 #Contact: {

--- a/schemas/layer-4.cue
+++ b/schemas/layer-4.cue
@@ -74,7 +74,7 @@ import "time"
 
 // Assessment defines all testing procedures for a requirement.
 #Assessment: {
-	// RequirementID is the unique identifier for the requirement being tested.
+	// RequirementId is the unique identifier for the requirement being tested.
 	"requirement-id": string @go(RequirementId)
 	// Procedures defines possible testing procedures to evaluate the requirement.
 	procedures: [...#AssessmentProcedure] @go(Procedures)

--- a/schemas/layer-4.cue
+++ b/schemas/layer-4.cue
@@ -7,17 +7,50 @@ import "time"
 	...
 }
 
+#EvaluationPlan: {
+	metadata: #Metadata
+	plans: [...#AssessmentPlan]
+}
+
+// AssessmentPlan defines all testing procedures for a control id.
+#AssessmentPlan: {
+	"control-id": string @go(ControlId)
+	"assessments": [...#Assessment] @go(Assessments)
+}
+
 #ControlEvaluation: {
 	name:              string
 	"control-id":      string @go(ControlId)
 	result:            #Result
 	message:           string
 	"corrupted-state": bool @go(CorruptedState)
-	assessments: [...#Assessment]
+	"assessment-logs": [...#AssessmentLog] @go(AssessmentLogs)
 }
 
+// AssessmentPlan defines all testing procedures for a requirement.
 #Assessment: {
+	// RequirementID is the unique identifier for the requirement being tested
 	"requirement-id": string @go(RequirementId)
+	// Procedures defined possible testing procedures to evaluate the requirement.
+	procedures: [...#AssessmentProcedure] @go(Procedures)
+}
+
+// AssessmentProcedure describes a testing procedure for evaluating a Layer 2 control requirement.
+#AssessmentProcedure: {
+	// Id uniquely identifies the assessment procedure being executed
+	id: string
+	// Name provides a summary of the procedure
+	name: string
+	// Description provides a detailed explanation of the procedure
+	description: string
+	// Documentation provides a URL to documentation that describes how the assessment procedure evaluates the control requirement
+	documentation?: =~"^https?://[^\\s]+$"
+}
+
+#AssessmentLog: {
+	"requirement-id": string @go(RequirementId)
+	// ProcedureId uniquely identifies the assessment procedure associated with the log
+	"procedure-id"?:  string @go(ProcedureId)
 	applicability: [...string]
 	description: string
 	result:      #Result
@@ -45,3 +78,24 @@ import "time"
 #Result: "Not Run" | "Passed" | "Failed" | "Needs Review" | "Not Applicable" | "Unknown"
 
 #Datetime: time.Format("2006-01-02T15:04:05Z07:00") @go(Datetime,format="date-time")
+
+#Metadata: {
+	id:      string
+	version?: string
+	author:  #Contact
+}
+
+#Contact: {
+	// The contact person's name.
+	name: string
+	// Indicates whether this admin is the first point of contact for inquiries. Only one entry should be marked as primary.
+	primary: bool
+	// The entity with which the contact is affiliated, such as a school or employer.
+	affiliation?: string @go(Affiliation,type=*string)
+	// A preferred email address to reach the contact.
+	email?: #Email @go(Email,type=*Email)
+	// A social media handle or profile for the contact.
+	social?: string @go(Social,type=*string)
+}
+
+#Email: =~"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"

--- a/schemas/layer-4.cue
+++ b/schemas/layer-4.cue
@@ -27,11 +27,11 @@ import "time"
 	"assessment-logs": [...#AssessmentLog] @go(AssessmentLogs)
 }
 
-// AssessmentPlan defines all testing procedures for a requirement.
+// Assessment defines all testing procedures for a requirement.
 #Assessment: {
-	// RequirementID is the unique identifier for the requirement being tested
+	// RequirementID is the unique identifier for the requirement being tested.
 	"requirement-id": string @go(RequirementId)
-	// Procedures defined possible testing procedures to evaluate the requirement.
+	// Procedures defines possible testing procedures to evaluate the requirement.
 	procedures: [...#AssessmentProcedure] @go(Procedures)
 }
 

--- a/schemas/layer-4.cue
+++ b/schemas/layer-4.cue
@@ -2,22 +2,14 @@ package schemas
 
 import "time"
 
+// EvaluationResults contains the results of evaluating a set of Layer 4 controls.
 #EvaluationResults: {
 	"evaluation-set": [#ControlEvaluation, ...#ControlEvaluation] @go(EvaluationSet)
 	...
 }
 
-#EvaluationPlan: {
-	metadata: #Metadata
-	plans: [...#AssessmentPlan]
-}
-
-// AssessmentPlan defines all testing procedures for a control id.
-#AssessmentPlan: {
-	"control-id": string @go(ControlId)
-	"assessments": [...#Assessment] @go(Assessments)
-}
-
+// ControlEvaluation contains the results of evaluating a single Layer 4 control.
+// TODO: are all control requirements guaranteed to be evaluated at once, or does applicability influence this?
 #ControlEvaluation: {
 	name:              string
 	"control-id":      string @go(ControlId)
@@ -27,27 +19,9 @@ import "time"
 	"assessment-logs": [...#AssessmentLog] @go(AssessmentLogs)
 }
 
-// Assessment defines all testing procedures for a requirement.
-#Assessment: {
-	// RequirementID is the unique identifier for the requirement being tested.
-	"requirement-id": string @go(RequirementId)
-	// Procedures defines possible testing procedures to evaluate the requirement.
-	procedures: [...#AssessmentProcedure] @go(Procedures)
-}
-
-// AssessmentProcedure describes a testing procedure for evaluating a Layer 2 control requirement.
-#AssessmentProcedure: {
-	// Id uniquely identifies the assessment procedure being executed
-	id: string
-	// Name provides a summary of the procedure
-	name: string
-	// Description provides a detailed explanation of the procedure
-	description: string
-	// Documentation provides a URL to documentation that describes how the assessment procedure evaluates the control requirement
-	documentation?: =~"^https?://[^\\s]+$"
-}
-
+// AssessmentLog contains the results of executing a single assessment procedure for a control requirement.
 #AssessmentLog: {
+	// RequirementId identifies the control requirement assessed.
 	"requirement-id": string @go(RequirementId)
 	// ProcedureId uniquely identifies the assessment procedure associated with the log
 	"procedure-id"?: string @go(ProcedureId)
@@ -79,10 +53,43 @@ import "time"
 
 #Datetime: time.Format("2006-01-02T15:04:05Z07:00") @go(Datetime,format="date-time")
 
+// EvaluationPlan defines how a set of Layer 4 controls are to be evaluated.
+#EvaluationPlan: {
+	metadata: #Metadata
+	plans: [...#AssessmentPlan]
+}
+
+// Metadata contains metadata about the evaluation plan.
 #Metadata: {
 	id:       string
 	version?: string
 	author:   #Contact
+}
+
+// AssessmentPlan defines all testing procedures for a control id.
+#AssessmentPlan: {
+	"control-id": string @go(ControlId)
+	"assessments": [...#Assessment] @go(Assessments)
+}
+
+// Assessment defines all testing procedures for a requirement.
+#Assessment: {
+	// RequirementID is the unique identifier for the requirement being tested.
+	"requirement-id": string @go(RequirementId)
+	// Procedures defines possible testing procedures to evaluate the requirement.
+	procedures: [...#AssessmentProcedure] @go(Procedures)
+}
+
+// AssessmentProcedure describes a testing procedure for evaluating a Layer 2 control requirement.
+#AssessmentProcedure: {
+	// Id uniquely identifies the assessment procedure being executed
+	id: string
+	// Name provides a summary of the procedure
+	name: string
+	// Description provides a detailed explanation of the procedure
+	description: string
+	// Documentation provides a URL to documentation that describes how the assessment procedure evaluates the control requirement
+	documentation?: =~"^https?://[^\\s]+$"
 }
 
 #Contact: {


### PR DESCRIPTION
## What Changed?

Introduce a new top level object to describe a test plan including `AssessmentProcedure`.

**Usage**: To support a human-led assessment, a test plan can described in an `EvaluationPlan` and a specific testing procedure can be described for a requirement.

Initially proposing, instead of duplicating this information in the `EvaluationResults`, the procedure can optionally be linked to an outcome of an `Assessment`.

Related to https://github.com/ossf/gemara/pull/113#issuecomment-3217411008
Supersedes #83

:warning: The breaking change here is for naming: `Assessment` -> `AssessmentLog`, but I'm open to other ideas on the naming.