### PR TITLE
fix: allow unknown fields in catalogs

### DIFF
--- a/layer2/loaders.go
+++ b/layer2/loaders.go
@@ -95,7 +95,7 @@ func (c *Catalog) LoadFile(sourcePath string) error {
 
 // decode unmarshals the provided reader into the provided Catalog object.
 func decode(reader io.Reader, data *Catalog) error {
-	decoder := yaml.NewDecoder(reader, yaml.DisallowUnknownField())
+	decoder := yaml.NewDecoder(reader)
 	err := decoder.Decode(data)
 	if err != nil {
 		return fmt.Errorf("error decoding YAML: %w", err)

--- a/layer2/loaders_test.go
+++ b/layer2/loaders_test.go
@@ -108,10 +108,9 @@ func Test_loadYamlFromURL(t *testing.T) {
 			wantErr:    false,
 		},
 		{
-			name:          "Valid URL with invalid data",
-			sourcePath:    "https://github.com/ossf/security-insights-spec/releases/download/v2.0.0/template-minimum.yml",
-			wantErr:       true,
-			errorExpected: "failed to decode YAML from URL:",
+			name:       "Valid URL with non-compatible content",
+			sourcePath: "https://github.com/ossf/security-insights-spec/releases/download/v2.0.0/template-minimum.yml",
+			wantErr:    false, // We no longer fail on unknown fields, only malformed
 		},
 	}
 
@@ -122,7 +121,7 @@ func Test_loadYamlFromURL(t *testing.T) {
 			if err != nil && tt.wantErr {
 				assert.Containsf(t, err.Error(), tt.errorExpected, "expected error containing %q, got %s", tt.errorExpected, err)
 			} else if err == nil && tt.wantErr {
-				t.Errorf("loadYamlFromURL() expected error matching %s, got nil.", tt.errorExpected)
+				t.Error("loadYamlFromURL() expected error, got none.")
 			}
 		})
 	}

--- a/layer2/test-data/bad.yaml
+++ b/layer2/test-data/bad.yaml
@@ -1,2 +1,3 @@
 this: file
 is: nonsense
+metadata: shouldn't be a string


### PR DESCRIPTION
Related to #119, our library should only tip over if expected fields contain malformed data. This will allow users such as CCC to embed additional information in the catalog file without needing to nest them alongside each other or release multiple artifacts side-by-side.