### PR TITLE
fix: Load Imported Capabilities, Threats, and Controls

### DIFF
--- a/layer2/loaders.go
+++ b/layer2/loaders.go
@@ -23,6 +23,9 @@ func (c *Catalog) LoadFiles(sourcePaths []string) error {
 		c.ControlFamilies = append(c.ControlFamilies, catalog.ControlFamilies...)
 		c.Capabilities = append(c.Capabilities, catalog.Capabilities...)
 		c.Threats = append(c.Threats, catalog.Threats...)
+		c.ImportedControls = append(c.ImportedControls, catalog.ImportedControls...)
+		c.ImportedCapabilities = append(c.ImportedCapabilities, catalog.ImportedCapabilities...)
+		c.ImportedThreats = append(c.ImportedThreats, catalog.ImportedThreats...)
 	}
 	return nil
 }


### PR DESCRIPTION
Found another oversight in the catalog loader, it wasn't loading data from the "import" fields.