### PR TITLE
refactor: updates internal OSCAL version const to go-oscal

### DIFF
--- a/internal/oscal/utils.go
+++ b/internal/oscal/utils.go
@@ -11,10 +11,7 @@ import (
 	oscal "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
 )
 
-const (
-	OSCALVersion    = "1.1.3"
-	GemaraNamespace = "https://github.com/ossf/gemara/ns/oscal"
-)
+const GemaraNamespace = "https://github.com/ossf/gemara/ns/oscal"
 
 // NilIfEmpty returns a pointer to the slice, or nil if empty.
 func NilIfEmpty[T any](slice []T) *[]T {
@@ -62,7 +59,7 @@ func GetTime(timeStr string) *time.Time {
 }
 
 func Validate(oscalModels oscal.OscalModels) error {
-	validator, err := oscalValidation.NewValidatorDesiredVersion(oscalModels, OSCALVersion)
+	validator, err := oscalValidation.NewValidatorDesiredVersion(oscalModels, oscal.Version)
 	if err != nil {
 		return fmt.Errorf("failed to create validator: %w", err)
 	}

--- a/layer1/oscal_generator.go
+++ b/layer1/oscal_generator.go
@@ -165,7 +165,7 @@ func createMetadata(guidance *GuidanceDocument, opts generateOpts) (oscal.Metada
 	fallbackTime := time.Now()
 	metadata := oscal.Metadata{
 		Title:        guidance.Metadata.Title,
-		OscalVersion: oscalUtils.OSCALVersion,
+		OscalVersion: oscal.Version,
 		Version:      opts.version,
 		Published:    oscalUtils.GetTime(guidance.Metadata.PublicationDate),
 		LastModified: oscalUtils.GetTimeWithFallback(guidance.Metadata.LastModified, fallbackTime),

--- a/layer2/oscal_generator.go
+++ b/layer2/oscal_generator.go
@@ -34,7 +34,7 @@ func (c *Catalog) ToOSCAL(controlHREF string) (oscal.Catalog, error) {
 					Rel:  "canonical",
 				},
 			},
-			OscalVersion: oscalUtils.OSCALVersion,
+			OscalVersion: oscal.Version,
 			Published:    &now,
 			Title:        c.Metadata.Title,
 			Version:      c.Metadata.Version,


### PR DESCRIPTION
This PR updates the `oscal_generator` functionality in Layer 1 and Layer 2 to use the OSCAL version constant defined in `go-oscal` from OSCAL version-specific package. The constant was recenlty added in version 0.7.0 of `go-oscal`. Using this value instead of the internally defined constant in `gemara` is useful when supporting multiple OSCAL versions.