### PR TITLE
feat: transform recommendation to guidance in layer2 OSCAL generation

### DIFF
--- a/layer2/oscal_generator.go
+++ b/layer2/oscal_generator.go
@@ -68,7 +68,7 @@ func (c *Catalog) ToOSCAL(controlHREF string) (oscal.Catalog, error) {
 			var subControls []oscal.Control
 			for _, ar := range control.AssessmentRequirements {
 				subControl := oscal.Control{
-					ID:    fmt.Sprintf("%s.%s", control.Id, ar.Id),
+					ID:    ar.Id,
 					Title: ar.Id,
 					Parts: &[]oscal.Part{
 						{

--- a/layer2/oscal_generator.go
+++ b/layer2/oscal_generator.go
@@ -62,8 +62,8 @@ func (c *Catalog) ToOSCAL(controlHREF string) (oscal.Catalog, error) {
 					Ns:    "",
 					Parts: &[]oscal.Part{
 						{
-							ID:    ar.Id + ".R",
-							Name:  "recommendation",
+							ID:    fmt.Sprintf("%s_smt.%s_gdn", control.Id, ar.Id),
+							Name:  "guidance",
 							Ns:    oscalUtils.GemaraNamespace,
 							Prose: ar.Recommendation,
 							Links: &[]oscal.Link{

--- a/layer2/test-data/good-osps.yml
+++ b/layer2/test-data/good-osps.yml
@@ -449,7 +449,7 @@ control-families:
               Assign a unique version identifier to each release produced by the
               project, following a consistent naming convention or numbering scheme.
               Examples include SemVer, CalVer, or git commit id.
-          - id: OSPS-BR-02.01
+          - id: OSPS-BR-02.02
             text: |
               When an official release is created, all assets within that release
               MUST be clearly associated with the release identifier or another


### PR DESCRIPTION
## Description
Aligned layer2's OSCAL generation with layer1's implementation by transforming "recommendation" to "guidance". 

## Changes Made
- Changed part name from "recommendation" to "guidance" to match layer1's implementation
- Updated ID format to match layer1's format: `{controlId}_smt.{partId}_gdn`

## Reference
Original layer1 implementation: https://github.com/ossf/gemara/blob/609b7a07b81e5a84cde8eb620f2885906ead80ba/layer1/oscal_generator.go#L286-L295
