### PR TITLE
fix: update dependabot labels

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,6 +7,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    labels: ["go", "dependencies"]
     groups:
       dependencies:
         applies-to: version-updates
@@ -19,6 +20,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    labels: ["github_actions", "dependencies"]
     groups:
       dependencies:
         applies-to: version-updates

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -32,15 +32,18 @@ version-resolver:
   major:
     labels:
       - "breaking"
+      - "major"
   minor:
     labels:
       - "feature"
       - "enhancement"
+      - "minor"
   patch:
     labels:
       - "fix"
       - "documentation"
       - "maintenance"
+      - "patch"
   default: patch
 autolabeler:
   - label: "automation"


### PR DESCRIPTION
Based on [Dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#labels--) we can specify the labels applied. Previously Dependabot was applying `major`, `minor', or `patch` labels based on the version of dependency updates. This was causing conflicts with our auto releasing. If those labels were present they were being applied to our releases. This is not what we want. We are chaning to just note the package type (i.e., go, github_actions, etc) and `dependencies`, in case we ever need to filter in the UI.

This allows us to put `major`, `minor`, and `patch` labels back into release-drafter.yml config so we can label our PRs manually to trigger those types of semver releases.