### PR TITLE
fix: Reorganized layer4 top level context

### DIFF
--- a/layer4/evaluation_plan.go
+++ b/layer4/evaluation_plan.go
@@ -2,64 +2,74 @@ package layer4
 
 // EvaluationPlan defines how a set of Layer 4 controls are to be evaluated.
 type EvaluationPlan struct {
-	Metadata	Metadata	`json:"metadata" yaml:"metadata"`
+	Metadata Metadata `json:"metadata" yaml:"metadata"`
 
-	Plans	[]AssessmentPlan	`json:"plans" yaml:"plans"`
+	Plans []AssessmentPlan `json:"plans" yaml:"plans"`
 }
 
-// Metadata contains metadata about the evaluation plan.
+// Metadata contains metadata about the evaluation plan or evaluation log.
 type Metadata struct {
-	Id	string	`json:"id" yaml:"id"`
+	Id string `json:"id" yaml:"id"`
 
-	Version	string	`json:"version,omitempty" yaml:"version,omitempty"`
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 
-	Author	Contact	`json:"author" yaml:"author"`
+	Evaluator Evaluator `json:"evaluator" yaml:"evaluator"`
+}
+
+type Evaluator struct {
+	Name string `json:"name" yaml:"name"`
+
+	URI string `json:"uri,omitempty" yaml:"uri,omitempty"`
+
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+
+	Contact Contact `json:"contact" yaml:"contact"`
 }
 
 type Contact struct {
 	// The contact person's name.
-	Name	string	`json:"name" yaml:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Indicates whether this admin is the first point of contact for inquiries. Only one entry should be marked as primary.
-	Primary	bool	`json:"primary" yaml:"primary"`
+	Primary bool `json:"primary" yaml:"primary"`
 
 	// The entity with which the contact is affiliated, such as a school or employer.
-	Affiliation	*string	`json:"affiliation,omitempty" yaml:"affiliation,omitempty"`
+	Affiliation *string `json:"affiliation,omitempty" yaml:"affiliation,omitempty"`
 
 	// A preferred email address to reach the contact.
-	Email	*string	`json:"email,omitempty" yaml:"email,omitempty"`
+	Email *string `json:"email,omitempty" yaml:"email,omitempty"`
 
 	// A social media handle or profile for the contact.
-	Social	*string	`json:"social,omitempty" yaml:"social,omitempty"`
+	Social *string `json:"social,omitempty" yaml:"social,omitempty"`
 }
 
 // AssessmentPlan defines all testing procedures for a control id.
 type AssessmentPlan struct {
-	ControlId	string	`json:"control-id" yaml:"control-id"`
+	ControlId string `json:"control-id" yaml:"control-id"`
 
-	Assessments	[]Assessment	`json:"assessments" yaml:"assessments"`
+	Assessments []Assessment `json:"assessments" yaml:"assessments"`
 }
 
 // Assessment defines all testing procedures for a requirement.
 type Assessment struct {
 	// RequirementId is the unique identifier for the requirement being tested.
-	RequirementId	string	`json:"requirement-id" yaml:"requirement-id"`
+	RequirementId string `json:"requirement-id" yaml:"requirement-id"`
 
 	// Procedures defines possible testing procedures to evaluate the requirement.
-	Procedures	[]AssessmentProcedure	`json:"procedures" yaml:"procedures"`
+	Procedures []AssessmentProcedure `json:"procedures" yaml:"procedures"`
 }
 
 // AssessmentProcedure describes a testing procedure for evaluating a Layer 2 control requirement.
 type AssessmentProcedure struct {
 	// Id uniquely identifies the assessment procedure being executed
-	Id	string	`json:"id" yaml:"id"`
+	Id string `json:"id" yaml:"id"`
 
 	// Name provides a summary of the procedure
-	Name	string	`json:"name" yaml:"name"`
+	Name string `json:"name" yaml:"name"`
 
 	// Description provides a detailed explanation of the procedure
-	Description	string	`json:"description" yaml:"description"`
+	Description string `json:"description" yaml:"description"`
 
 	// Documentation provides a URL to documentation that describes how the assessment procedure evaluates the control requirement
-	Documentation	string	`json:"documentation,omitempty" yaml:"documentation,omitempty"`
+	Documentation string `json:"documentation,omitempty" yaml:"documentation,omitempty"`
 }

--- a/layer4/to_sarif_test.go
+++ b/layer4/to_sarif_test.go
@@ -34,10 +34,18 @@ func Test_ToSARIF(t *testing.T) {
 	}
 	informationURI := "https://github.com/ossf/gemara"
 	version := "1.0.0"
-	semanticVersion := "1.0.0"
-	dottedQuadFileVersion := "1.0.0.0"
 
-	sarifBytes, err := ToSARIF("gemara", informationURI, version, semanticVersion, dottedQuadFileVersion, []*ControlEvaluation{ce})
+	evaluationLog := EvaluationLog{
+		Evaluations: []*ControlEvaluation{ce},
+		Metadata: Metadata{
+			Evaluator: Evaluator{
+				Name:    "gemara",
+				URI:     informationURI,
+				Version: version,
+			},
+		},
+	}
+	sarifBytes, err := evaluationLog.ToSARIF()
 	require.NoError(t, err)
 	sarif = &SarifReport{}
 	err = json.Unmarshal(sarifBytes, sarif)
@@ -65,8 +73,6 @@ func Test_ToSARIF(t *testing.T) {
 	require.Equal(t, "gemara", run.Tool.Driver.Name)
 	require.Equal(t, informationURI, run.Tool.Driver.InformationURI)
 	require.Equal(t, version, run.Tool.Driver.Version)
-	require.Equal(t, semanticVersion, run.Tool.Driver.SemanticVersion)
-	require.Equal(t, dottedQuadFileVersion, run.Tool.Driver.DottedQuadFileVersion)
 
 	// ensure JSON marshals cleanly
 	_, err = json.Marshal(sarif)

--- a/schemas/layer-4.cue
+++ b/schemas/layer-4.cue
@@ -2,7 +2,6 @@ package schemas
 
 import "time"
 
-
 // EvaluationPlan defines how a set of Layer 4 controls are to be evaluated.
 #EvaluationPlan: {
 	metadata: #Metadata
@@ -17,15 +16,15 @@ import "time"
 
 // Metadata contains metadata about the evaluation plan.
 #Metadata: {
-	id:       string
-	version?: string
+	id:        string
+	version?:  string
 	evaluator: #Evaluator
 }
 
 // Evaluator contains the information about the entity that produced the evaluation results.
 #Evaluator: {
-	"name": string
-	"uri"?: string
+	"name":     string
+	"uri"?:     string
 	"version"?: string
 	"contact"?: #Contact @go(Contact)
 }

--- a/schemas/layer-4.cue
+++ b/schemas/layer-4.cue
@@ -2,10 +2,32 @@ package schemas
 
 import "time"
 
-// EvaluationResults contains the results of evaluating a set of Layer 4 controls.
-#EvaluationResults: {
-	"evaluation-set": [#ControlEvaluation, ...#ControlEvaluation] @go(EvaluationSet)
-	...
+
+// EvaluationPlan defines how a set of Layer 4 controls are to be evaluated.
+#EvaluationPlan: {
+	metadata: #Metadata
+	plans: [...#AssessmentPlan]
+}
+
+// EvaluationLog contains the results of evaluating a set of Layer 4 controls.
+#EvaluationLog: {
+	"evaluations": [#ControlEvaluation, ...#ControlEvaluation] @go(Evaluations)
+	"metadata"?: #Metadata @go(Metadata)
+}
+
+// Metadata contains metadata about the evaluation plan.
+#Metadata: {
+	id:       string
+	version?: string
+	evaluator: #Evaluator
+}
+
+// Evaluator contains the information about the entity that produced the evaluation results.
+#Evaluator: {
+	"name": string
+	"uri"?: string
+	"version"?: string
+	"contact"?: #Contact @go(Contact)
 }
 
 // ControlEvaluation contains the results of evaluating a single Layer 4 control.
@@ -52,19 +74,6 @@ import "time"
 #Result: "Not Run" | "Passed" | "Failed" | "Needs Review" | "Not Applicable" | "Unknown"
 
 #Datetime: time.Format("2006-01-02T15:04:05Z07:00") @go(Datetime,format="date-time")
-
-// EvaluationPlan defines how a set of Layer 4 controls are to be evaluated.
-#EvaluationPlan: {
-	metadata: #Metadata
-	plans: [...#AssessmentPlan]
-}
-
-// Metadata contains metadata about the evaluation plan.
-#Metadata: {
-	id:       string
-	version?: string
-	author:   #Contact
-}
 
 // AssessmentPlan defines all testing procedures for a control id.
 #AssessmentPlan: {

--- a/schemas/layer-4.cue
+++ b/schemas/layer-4.cue
@@ -2,19 +2,19 @@ package schemas
 
 import "time"
 
-// EvaluationPlan defines how a set of Layer 4 controls are to be evaluated.
+// EvaluationPlan defines how a set of Layer 2 controls are to be evaluated.
 #EvaluationPlan: {
 	metadata: #Metadata
 	plans: [...#AssessmentPlan]
 }
 
-// EvaluationLog contains the results of evaluating a set of Layer 4 controls.
+// EvaluationLog contains the results of evaluating a set of Layer 2 controls.
 #EvaluationLog: {
 	"evaluations": [#ControlEvaluation, ...#ControlEvaluation] @go(Evaluations)
 	"metadata"?: #Metadata @go(Metadata)
 }
 
-// Metadata contains metadata about the evaluation plan.
+// Metadata contains metadata about the Layer 4 evaluation plan and log.
 #Metadata: {
 	id:        string
 	version?:  string


### PR DESCRIPTION
addresses #149 

This pull request refactors how evaluation metadata is represented and passed throughout the Layer 4 evaluation codebase. The main changes include introducing a new `Evaluator` struct, updating the `Metadata` struct to use it, and updating the SARIF export logic and corresponding tests to match the new structure. The CUE schema is also updated to reflect these changes.