### PR TITLE
fix: add implementation plan to layer 3 policy doc

### DIFF
--- a/layer3/generated_types.go
+++ b/layer3/generated_types.go
@@ -10,6 +10,8 @@ type PolicyDocument struct {
 
 	Scope	Scope	`json:"scope" yaml:"scope"`
 
+	ImplementationPlan	ImplementationPlan	`json:"implementation-plan,omitempty" yaml:"implementation-plan,omitempty"`
+
 	GuidanceReferences	[]Mapping	`json:"guidance-references" yaml:"guidance-references"`
 
 	ControlReferences	[]Mapping	`json:"control-references" yaml:"control-references"`
@@ -87,6 +89,40 @@ type Scope struct {
 	Providers	[]string	`json:"providers,omitempty" yaml:"providers,omitempty"`
 }
 
+type ImplementationPlan struct {
+	// The process through which notified parties should be made aware of this policy
+	NotifactionProcess	string	`json:"notification-process,omitempty" yaml:"notification-process,omitempty"`
+
+	NotifiedParties	[]NotificationGroup	`json:"notified-parties,omitempty" yaml:"notified-parties,omitempty"`
+
+	Evaluation	ImplementationDetails	`json:"evaluation" yaml:"evaluation"`
+
+	EvaluationPoints	[]EvaluationPoint	`json:"evaluation-points,omitempty" yaml:"evaluation-points,omitempty"`
+
+	Enforcement	ImplementationDetails	`json:"enforcement" yaml:"enforcement"`
+
+	EnforcementMethods	[]EnforcementMethod	`json:"enforcement-methods,omitempty" yaml:"enforcement-methods,omitempty"`
+
+	// The process that will be followed in the event that noncompliance is detected in an applicable resource
+	NoncompliancePlan	string	`json:"noncompliance-plan,omitempty" yaml:"noncompliance-plan,omitempty"`
+}
+
+type NotificationGroup string
+
+type ImplementationDetails struct {
+	Start	Datetime	`json:"start" yaml:"start"`
+
+	End	Datetime	`json:"end,omitempty" yaml:"end,omitempty"`
+
+	Notes	string	`json:"notes" yaml:"notes"`
+}
+
+type Datetime string
+
+type EvaluationPoint string
+
+type EnforcementMethod string
+
 type Mapping struct {
 	ReferenceId	string	`json:"reference-id" yaml:"reference-id"`
 
@@ -155,40 +191,6 @@ type GuidelineModifier struct {
 
 	ExternalReferences	[]string	`json:"external-references,omitempty" yaml:"external-references,omitempty"`
 }
-
-type ImplementationPlan struct {
-	// The process through which notified parties should be made aware of this policy
-	NotifactionProcess	string	`json:"notification-process,omitempty" yaml:"notification-process,omitempty"`
-
-	NotifiedParties	[]NotificationGroup	`json:"notified-parties,omitempty" yaml:"notified-parties,omitempty"`
-
-	Evaluation	ImplementationDetails	`json:"evaluation" yaml:"evaluation"`
-
-	EvaluationPoints	[]EvaluationPoint	`json:"evaluation-points,omitempty" yaml:"evaluation-points,omitempty"`
-
-	Enforcement	ImplementationDetails	`json:"enforcement" yaml:"enforcement"`
-
-	EnforcementMethods	[]EnforcementMethod	`json:"enforcement-methods,omitempty" yaml:"enforcement-methods,omitempty"`
-
-	// The process that will be followed in the event that noncompliance is detected in an applicable resource
-	NoncompliancePlan	string	`json:"noncompliance-plan,omitempty" yaml:"noncompliance-plan,omitempty"`
-}
-
-type NotificationGroup string
-
-type ImplementationDetails struct {
-	Start	Datetime	`json:"start" yaml:"start"`
-
-	End	Datetime	`json:"end,omitempty" yaml:"end,omitempty"`
-
-	Notes	string	`json:"notes" yaml:"notes"`
-}
-
-type Datetime string
-
-type EvaluationPoint string
-
-type EnforcementMethod string
 
 type PartModifier struct {
 	TargetId	string	`json:"target-id" yaml:"target-id"`

--- a/schemas/layer-3.cue
+++ b/schemas/layer-3.cue
@@ -9,8 +9,9 @@ import "time"
 	metadata: #Metadata
 	contacts: #Contacts
 	scope:    #Scope
-	"guidance-references": [...#Mapping] @go(GuidanceReferences) @yaml("guidance-references",omitempty)
-	"control-references": [...#Mapping] @go(ControlReferences) @yaml("control-references",omitempty)
+	"implementation-plan"?: #ImplementationPlan @go(ImplementationPlan) @yaml("implementation-plan,omitempty")
+	"guidance-references": [...#Mapping] @go(GuidanceReferences) @yaml("guidance-references")
+	"control-references": [...#Mapping] @go(ControlReferences) @yaml("control-references")
 }
 
 #Metadata: {
@@ -21,9 +22,9 @@ import "time"
 	contacts:  #Contacts
 
 	"last-modified":    string @go(LastModified) @yaml("last-modified,omitempty")
-	"organization-id"?: string @go(OrganizationID) @yaml("organization-id",omitempty)
+	"organization-id"?: string @go(OrganizationID) @yaml("organization-id,omitempty")
 	"author-notes?":    string @go(AuthorNotes) @yaml("author-notes",omitempty)
-	"mapping-references"?: [...#MappingReference] @go(MappingReferences) @yaml("mapping-references",omitempty)
+	"mapping-references"?: [...#MappingReference] @go(MappingReferences) @yaml("mapping-references,omitempty")
 }
 
 #Contacts: {

--- a/schemas/layer-3.cue
+++ b/schemas/layer-3.cue
@@ -6,9 +6,9 @@ import "time"
 
 // Core Document Structure
 #PolicyDocument: {
-	metadata: #Metadata
-	contacts: #Contacts
-	scope:    #Scope
+	metadata:               #Metadata
+	contacts:               #Contacts
+	scope:                  #Scope
 	"implementation-plan"?: #ImplementationPlan @go(ImplementationPlan) @yaml("implementation-plan,omitempty")
 	"guidance-references": [...#Mapping] @go(GuidanceReferences) @yaml("guidance-references")
 	"control-references": [...#Mapping] @go(ControlReferences) @yaml("control-references")


### PR DESCRIPTION
The `ImplementationPlan` is defined in the `layer3` schema, but not connected to the `PolicyDocument`.

This PR adds the `implementation-plan` as an optional field to the policy document. Is it optional to avoid breaking changes.