### PR TITLE
chore: mark Layer 5 log and Layer 2 catalogs as stable

### DIFF
--- a/capabilitycatalog.cue
+++ b/capabilitycatalog.cue
@@ -1,5 +1,5 @@
 // Schema lifecycle: experimental | stable | deprecated
-@status("experimental")
+@status("stable")
 package gemara
 
 @go(gemara)

--- a/collections.cue
+++ b/collections.cue
@@ -33,9 +33,6 @@ package gemara
 	}
 }
 
-// Lifecycle represents the lifecycle state of a guideline, control, or assessment requirement
-#Lifecycle: *"Active" | "Draft" | "Deprecated" | "Retired" @go(-)
-
 // Log describes a set of recorded entries from a measurement activity
 #Log: {
 	// metadata provides detailed data about this log
@@ -44,3 +41,9 @@ package gemara
 	// target identifies the resource being evaluated
 	target: #Resource @go(Target)
 }
+
+// Lifecycle represents the lifecycle state of a guideline, control, or assessment requirement
+#Lifecycle: *"Active" | "Draft" | "Deprecated" | "Retired" @go(-)
+
+// ConfidenceLevel indicates the evaluator's confidence level in an assessment result.
+#ConfidenceLevel: "Undetermined" | "Low" | "Medium" | "High" @go(-)

--- a/controlcatalog.cue
+++ b/controlcatalog.cue
@@ -1,5 +1,5 @@
 // Schema lifecycle: experimental | stable | deprecated
-@status("experimental")
+@status("stable")
 package gemara
 
 @go(gemara)

--- a/cue.mod/module.cue
+++ b/cue.mod/module.cue
@@ -1,6 +1,6 @@
 module: "github.com/gemaraproj/gemara"
 language: {
-	version: "v0.15.1"
+	version: "v0.16.0"
 }
 source: {
 	kind: "git"

--- a/cue.mod/module.cue
+++ b/cue.mod/module.cue
@@ -1,6 +1,6 @@
 module: "github.com/gemaraproj/gemara"
 language: {
-	version: "v0.15.4"
+	version: "v0.15.1"
 }
 source: {
 	kind: "git"

--- a/cue.mod/module.cue
+++ b/cue.mod/module.cue
@@ -1,6 +1,6 @@
 module: "github.com/gemaraproj/gemara"
 language: {
-	version: "v0.16.0"
+	version: "v0.15.4"
 }
 source: {
 	kind: "git"

--- a/docs/schema/index.md
+++ b/docs/schema/index.md
@@ -94,7 +94,7 @@ Schema documentation generated from CUE. One page per schema file:
 # Install CUE
 go install cuelang.org/go/cmd/cue@latest
 
-# Validate a control catalog using the Layer 2 ControlCatalog definition
+# Validate a control catalog using the ControlCatalog definition
 cue vet -c -d '#ControlCatalog' github.com/gemaraproj/gemara@latest your-controls.yaml
 ```
 
@@ -143,7 +143,7 @@ The core specification release versions the CUE schemas as a single unit.
 
 ### Schema Lifecycle and Major Version Example
 
-Possible schema states include: **Experimental** → **Stable** → **Deprecated**. These are denoted on each layer schema with a `@status(experimental|stable|deprecated)` attribute.
+Possible schema states include: **Experimental** → **Stable** → **Deprecated**. These are denoted on each schema file with a `@status(experimental|stable|deprecated)` attribute.
 
 The following table illustrates how schemas progress through their lifecycle and how major version changes are handled:
 
@@ -167,9 +167,9 @@ The following table illustrates how schemas progress through their lifecycle and
 
 ### Stable Status
 
-* Layers promote independently. Each layer only requires its direct dependencies to be Stable (e.g., Layer 2 requires Layer 1, but not Layer 6).
-* Layers can be promoted to Stable at different times. Layer 2 can be Stable while Layer 6 remains Experimental.
-* Stable schemas may only reference other Stable schemas.
+* Schemas promote independently and at different times (e.g., ControlCatalog can be Stable while Policy remains Experimental).
+* When a schema is promoted to Stable, all types it references must also be Stable (e.g., promoting `#ControlCatalog` requires `#Catalog`, `#Metadata`, `#Group`, and any other referenced types to already be Stable).
+* Stable schemas may only reference other Stable types.
 * Stable schemas maintain backward and forward compatibility within major versions, allowing **additive optional changes** only.
 * Breaking changes require major version increments and should be avoided in all normal circumstances.
 

--- a/evaluationlog.cue
+++ b/evaluationlog.cue
@@ -58,6 +58,3 @@ package gemara
 #AssessmentStep: string @go(-)
 
 #Result: "Not Run" | "Passed" | "Failed" | "Needs Review" | "Not Applicable" | "Unknown" @go(-)
-
-// ConfidenceLevel indicates the evaluator's confidence level in an assessment result.
-#ConfidenceLevel: "Undetermined" | "Low" | "Medium" | "High" @go(-)

--- a/evaluationlog.cue
+++ b/evaluationlog.cue
@@ -1,5 +1,5 @@
 // Schema lifecycle: experimental | stable | deprecated
-@status("experimental")
+@status("stable")
 package gemara
 
 @go(gemara)
@@ -58,3 +58,6 @@ package gemara
 #AssessmentStep: string @go(-)
 
 #Result: "Not Run" | "Passed" | "Failed" | "Needs Review" | "Not Applicable" | "Unknown" @go(-)
+
+// ConfidenceLevel indicates the evaluator's confidence level in an assessment result.
+#ConfidenceLevel: "Undetermined" | "Low" | "Medium" | "High" @go(-)

--- a/mappingdocument.cue
+++ b/mappingdocument.cue
@@ -98,6 +98,3 @@ package gemara
 
 // EntryType enumerates the atomic units within Gemara artifacts that can participate in mappings
 #EntryType: "Guideline" | "Statement" | "Control" | "AssessmentRequirement" | "Capability" | "Threat" | "Risk" | "Vector" @go(-)
-
-// ConfidenceLevel indicates the evaluator's confidence level in an assessment result.
-#ConfidenceLevel: "Undetermined" | "Low" | "Medium" | "High" @go(-)

--- a/threatcatalog.cue
+++ b/threatcatalog.cue
@@ -1,5 +1,5 @@
 // Schema lifecycle: experimental | stable | deprecated
-@status("experimental")
+@status("stable")
 package gemara
 
 @go(gemara)


### PR DESCRIPTION
## Description

This PR marks the follow types at stable to prepare for the RC.1:

- ControlCatalog
- ThreatCatalog
- CapabilityCatalog
- EvaluationLog   

## Schema Changes

### Schema Changes Made

- [ ] No schema changes
- [X] Control Catalog schema (`controlcatalog.cue`) changes
- [X] Capability Catalog schema (`capabilitycatalog.cue`) changes
- [ ] Enforcement Log schema (`enforcementlog.cue`) changes
- [X] Evaluation Log schema (`evaluationlog.cue`) changes
- [ ] Guidance Catalog schema (`guidancecatalog.cue`) changes
- [ ] Mapping Document schema (`mapping.cue`) changes
- [ ] Policy Document schema (`policy.cue`) changes
- [ ] Risk Catalog schema (`riskcatalog.cue`) changes
- [X] Threat Catalog schema (`threatcatalog.cue`) changes
- [ ] Vector Catalog schema (`vectorcatalog.cue`) changes
- [ ] Other

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->



 ---

## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [ ] This PR has content that was created with AI assistance. 
   - [ ]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [ ] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.