### PR TITLE
feat: add group and accepted method validations

### DIFF
--- a/capabilitycatalog.cue
+++ b/capabilitycatalog.cue
@@ -2,6 +2,8 @@
 @status("stable")
 package gemara
 
+import "list"
+
 @go(gemara)
 
 // CapabilityCatalog describes a collection of system capabilities
@@ -15,6 +17,11 @@ package gemara
 	if capabilities != _|_ {
 		_uniqueCapabilityIds: {for i, c in capabilities {(c.id): i}}
 		groups: [#Group, ...#Group]
+		let _validGroupIds = [for g in groups {g.id}]
+		// Unify the valid ID list with a list.Contains constraint to require each entry's value exists
+		for i, c in capabilities {
+			_groupValidation: "\(i)": _validGroupIds & list.Contains(c.group)
+		}
 	}
 }
 

--- a/capabilitycatalog.cue
+++ b/capabilitycatalog.cue
@@ -18,6 +18,7 @@ import "list"
 		_uniqueCapabilityIds: {for i, c in capabilities {(c.id): i}}
 		groups: [#Group, ...#Group]
 		let _validGroupIds = [for g in groups {g.id}]
+
 		// Unify the valid ID list with a list.Contains constraint to require each entry's value exists
 		for i, c in capabilities {
 			_groupValidation: "\(i)": _validGroupIds & list.Contains(c.group)

--- a/controlcatalog.cue
+++ b/controlcatalog.cue
@@ -2,6 +2,8 @@
 @status("stable")
 package gemara
 
+import "list"
+
 @go(gemara)
 
 // ControlCatalog describes a set of related controls and relevant metadata
@@ -15,6 +17,18 @@ package gemara
 	if controls != _|_ {
 		_uniqueControlIds: {for i, c in controls {(c.id): i}}
 		groups: [#Group, ...#Group]
+		metadata: "applicability-groups": [#Group, ...#Group]
+		let _validGroupIds = [for g in groups {g.id}]
+		let _validApplicabilityIds = [for ag in metadata."applicability-groups" {ag.id}]
+		// Unify the valid ID list with a list.Contains constraint to require each entry's value exists
+		for i, c in controls {
+			_groupValidation: "\(i)": _validGroupIds & list.Contains(c.group)
+			for j, ar in c."assessment-requirements" {
+				for k, a in ar.applicability {
+					_applicabilityValidation: "\(i)-\(j)-\(k)": _validApplicabilityIds & list.Contains(a)
+				}
+			}
+		}
 	}
 }
 

--- a/controlcatalog.cue
+++ b/controlcatalog.cue
@@ -20,6 +20,7 @@ import "list"
 		metadata: "applicability-groups": [#Group, ...#Group]
 		let _validGroupIds = [for g in groups {g.id}]
 		let _validApplicabilityIds = [for ag in metadata."applicability-groups" {ag.id}]
+
 		// Unify the valid ID list with a list.Contains constraint to require each entry's value exists
 		for i, c in controls {
 			_groupValidation: "\(i)": _validGroupIds & list.Contains(c.group)

--- a/guidancecatalog.cue
+++ b/guidancecatalog.cue
@@ -27,6 +27,7 @@ import "list"
 		_uniqueGuidelineIds: {for i, g in guidelines {(g.id): i}}
 		groups: [#Group, ...#Group]
 		let _validGroupIds = [for g in groups {g.id}]
+
 		// Unify the valid ID list with a list.Contains constraint to require each entry's value exists
 		for i, g in guidelines {
 			_groupValidation: "\(i)": _validGroupIds & list.Contains(g.group)

--- a/guidancecatalog.cue
+++ b/guidancecatalog.cue
@@ -2,6 +2,8 @@
 @status("experimental")
 package gemara
 
+import "list"
+
 @go(gemara)
 
 // GuidanceCatalog represents a concerted documentation effort to help bring about an optimal future without foreknowledge of the implementation details
@@ -24,6 +26,19 @@ package gemara
 	if guidelines != _|_ {
 		_uniqueGuidelineIds: {for i, g in guidelines {(g.id): i}}
 		groups: [#Group, ...#Group]
+		let _validGroupIds = [for g in groups {g.id}]
+		// Unify the valid ID list with a list.Contains constraint to require each entry's value exists
+		for i, g in guidelines {
+			_groupValidation: "\(i)": _validGroupIds & list.Contains(g.group)
+		}
+		if metadata."applicability-groups" != _|_ {
+			let _validApplicabilityIds = [for ag in metadata."applicability-groups" {ag.id}]
+			for i, g in guidelines if g.applicability != _|_ {
+				for j, a in g.applicability {
+					_applicabilityValidation: "\(i)-\(j)": _validApplicabilityIds & list.Contains(a)
+				}
+			}
+		}
 	}
 }
 

--- a/policy.cue
+++ b/policy.cue
@@ -124,8 +124,8 @@ package gemara
 
 #ModeType:              "Manual" | "Automated"                           @go(-)
 #MethodType:            "Behavioral" | "Intent" | "Remediation" | "Gate" @go(-)
-#EvaluationMethodType:  "Intent" | "Behavioral"                         @go(-)
-#EnforcementMethodType: "Gate" | "Remediation"                          @go(-)
+#EvaluationMethodType:  "Intent" | "Behavioral"                          @go(-)
+#EnforcementMethodType: "Gate" | "Remediation"                           @go(-)
 
 // Parameter defines a configurable parameter for assessment or enforcement activities.
 #Parameter: {

--- a/policy.cue
+++ b/policy.cue
@@ -96,9 +96,9 @@ package gemara
 
 // Adherence defines evaluation methods, assessment plans, enforcement methods, and non-compliance notifications.
 #Adherence: {
-	"evaluation-methods"?: [#AcceptedMethod, ...#AcceptedMethod] @go(EvaluationMethods)
+	"evaluation-methods"?: [#AcceptedMethod & {type: #EvaluationMethodType}, ...#AcceptedMethod & {type: #EvaluationMethodType}] @go(EvaluationMethods)
 	"assessment-plans"?: [#AssessmentPlan, ...#AssessmentPlan] @go(AssessmentPlans)
-	"enforcement-methods"?: [#AcceptedMethod, ...#AcceptedMethod] @go(EnforcementMethods)
+	"enforcement-methods"?: [#AcceptedMethod & {type: #EnforcementMethodType}, ...#AcceptedMethod & {type: #EnforcementMethodType}] @go(EnforcementMethods)
 	"non-compliance"?: string @go(NonCompliance)
 }
 
@@ -107,7 +107,7 @@ package gemara
 	id:               string
 	"requirement-id": string @go(RequirementId)
 	frequency:        string
-	"evaluation-methods": [#AcceptedMethod, ...#AcceptedMethod] @go(EvaluationMethods)
+	"evaluation-methods": [#AcceptedMethod & {type: #EvaluationMethodType}, ...#AcceptedMethod & {type: #EvaluationMethodType}] @go(EvaluationMethods)
 	"evidence-requirements"?: string @go(EvidenceRequirements)
 	parameters?: [#Parameter, ...#Parameter]
 }
@@ -122,8 +122,10 @@ package gemara
 	executor?:    #Actor
 }
 
-#ModeType:   "Manual" | "Automated"                           @go(-)
-#MethodType: "Behavioral" | "Intent" | "Remediation" | "Gate" @go(-)
+#ModeType:              "Manual" | "Automated"                           @go(-)
+#MethodType:            "Behavioral" | "Intent" | "Remediation" | "Gate" @go(-)
+#EvaluationMethodType:  "Intent" | "Behavioral"                         @go(-)
+#EnforcementMethodType: "Gate" | "Remediation"                          @go(-)
 
 // Parameter defines a configurable parameter for assessment or enforcement activities.
 #Parameter: {

--- a/principlecatalog.cue
+++ b/principlecatalog.cue
@@ -2,6 +2,8 @@
 @status("experimental")
 package gemara
 
+import "list"
+
 @go(gemara)
 
 // PrincipleCatalog describes a set of related principles and relevant metadata
@@ -15,6 +17,11 @@ package gemara
 	if principles != _|_ {
 		_uniquePrinciplesIds: {for i, p in principles {(p.id): i}}
 		groups: [#Group, ...#Group]
+		let _validGroupIds = [for g in groups {g.id}]
+		// Unify the valid ID list with a list.Contains constraint to require each entry's value exists
+		for i, p in principles {
+			_groupValidation: "\(i)": _validGroupIds & list.Contains(p.group)
+		}
 	}
 }
 

--- a/principlecatalog.cue
+++ b/principlecatalog.cue
@@ -18,6 +18,7 @@ import "list"
 		_uniquePrinciplesIds: {for i, p in principles {(p.id): i}}
 		groups: [#Group, ...#Group]
 		let _validGroupIds = [for g in groups {g.id}]
+
 		// Unify the valid ID list with a list.Contains constraint to require each entry's value exists
 		for i, p in principles {
 			_groupValidation: "\(i)": _validGroupIds & list.Contains(p.group)

--- a/riskcatalog.cue
+++ b/riskcatalog.cue
@@ -2,6 +2,8 @@
 @status("experimental")
 package gemara
 
+import "list"
+
 @go(gemara)
 
 // A RiskCatalog is a structured collection of documented risks that may affect an organization,
@@ -20,6 +22,11 @@ package gemara
 	if risks != _|_ {
 		_uniqueRiskIds: {for i, r in risks {(r.id): i}}
 		groups: [#RiskCategory, ...#RiskCategory]
+		let _validGroupIds = [for g in groups {g.id}]
+		// Unify the valid ID list with a list.Contains constraint to require each entry's value exists
+		for i, r in risks {
+			_groupValidation: "\(i)": _validGroupIds & list.Contains(r.group)
+		}
 	}
 }
 

--- a/riskcatalog.cue
+++ b/riskcatalog.cue
@@ -23,6 +23,7 @@ import "list"
 		_uniqueRiskIds: {for i, r in risks {(r.id): i}}
 		groups: [#RiskCategory, ...#RiskCategory]
 		let _validGroupIds = [for g in groups {g.id}]
+
 		// Unify the valid ID list with a list.Contains constraint to require each entry's value exists
 		for i, r in risks {
 			_groupValidation: "\(i)": _validGroupIds & list.Contains(r.group)

--- a/test/schema_test.go
+++ b/test/schema_test.go
@@ -107,6 +107,18 @@ func TestSchemaValidation(t *testing.T) {
 		// AuditLog — negative
 		{"audit log missing summary criteria and results", "./test-data/bad-audit-log.yaml", "#AuditLog", true, ""},
 
+		// CapabilityCatalog — negative
+		{"capability with invalid group", "./test-data/bad-capability-invalid-group.yaml", "#CapabilityCatalog", true, ""},
+
+		// ThreatCatalog — negative
+		{"threat with invalid group", "./test-data/bad-threat-invalid-group.yaml", "#ThreatCatalog", true, ""},
+
+		// PrincipleCatalog — negative
+		{"principle with invalid group", "./test-data/bad-principle-invalid-group.yaml", "#PrincipleCatalog", true, ""},
+
+		// ControlCatalog — negative (group validation)
+		{"control with invalid group", "./test-data/bad-control-invalid-group.yaml", "#ControlCatalog", true, ""},
+
 		// ControlCatalog — edge cases
 		{"empty nested catalog", "./test-data/nested-empty.yaml", "#ControlCatalog", false, ""},
 	}

--- a/test/test-data/bad-capability-invalid-group.yaml
+++ b/test/test-data/bad-capability-invalid-group.yaml
@@ -1,0 +1,23 @@
+metadata:
+  id: EXAMPLE-CAPABILITY-CATALOG
+  type: CapabilityCatalog
+  gemara-version: "0.20.0"
+  version: "1.0.0"
+  description: Example Capability Catalog
+  author:
+    id: security-team
+    name: Security Team
+    type: Human
+
+title: Example Capability Catalog
+
+groups:
+  - id: container-infrastructure
+    title: Container Infrastructure
+    description: Capabilities related to the core container infrastructure
+
+capabilities:
+  - id: CAP-001
+    title: Container Runtime
+    description: System's ability to run containerized applications.
+    group: nonexistent-group

--- a/test/test-data/bad-control-invalid-group.yaml
+++ b/test/test-data/bad-control-invalid-group.yaml
@@ -1,0 +1,34 @@
+metadata:
+  id: TEST-INVALID-GROUP
+  type: ControlCatalog
+  gemara-version: "0.20.0"
+  version: "1.0.0"
+  description: Control catalog with a control referencing an invalid group.
+  author:
+    id: test
+    name: Test Author
+    type: Human
+  applicability-groups:
+    - id: production
+      title: Production
+      description: Production environments.
+
+title: Invalid Group Test
+
+groups:
+  - id: access-control
+    title: Access Control
+    description: Controls related to access.
+
+controls:
+  - id: TC-001
+    group: nonexistent-group
+    title: Test Control
+    objective: Test objective.
+    state: Active
+    assessment-requirements:
+      - id: TC-001.AR01
+        text: Test requirement.
+        state: Active
+        applicability:
+          - production

--- a/test/test-data/bad-principle-invalid-group.yaml
+++ b/test/test-data/bad-principle-invalid-group.yaml
@@ -1,0 +1,22 @@
+title: AI Governance Framework Principles
+metadata:
+  id: AIR-PRIN
+  type: PrincipleCatalog
+  gemara-version: "0.20.0"
+  description: Core principles underpinning the FINOS AI Governance Framework.
+  version: 0.1.0
+  author:
+    id: finos
+    name: FINOS
+    type: Human
+
+groups:
+  - id: data-protection
+    title: Data Protection
+    description: Principles governing the handling of sensitive data within AI systems.
+
+principles:
+  - id: AIR-PRIN-001
+    title: Proactive Data Sanitization
+    group: nonexistent-group
+    description: Apply filtering and anonymization techniques before data enters the AI pipeline.

--- a/test/test-data/bad-threat-invalid-group.yaml
+++ b/test/test-data/bad-threat-invalid-group.yaml
@@ -1,0 +1,31 @@
+metadata:
+  id: EXAMPLE-THREAT-CATALOG
+  type: ThreatCatalog
+  gemara-version: "0.20.0"
+  version: "1.0.0"
+  description: Example Threat Catalog
+  author:
+    id: security-team
+    name: Security Team
+    type: Human
+  mapping-references:
+    - id: EXAMPLE-CAPABILITY-CATALOG
+      title: Example Capability Catalog
+      version: "1.0.0"
+
+title: Example Threat Catalog
+
+groups:
+  - id: stride-s
+    title: Spoofing
+    description: Impersonating something or someone to gain unauthorized access
+
+threats:
+  - id: THREAT-001
+    title: Exploitation of Vulnerable Container Images
+    description: Attackers exploit known vulnerabilities in container images.
+    group: nonexistent-group
+    capabilities:
+      - reference-id: EXAMPLE-CAPABILITY-CATALOG
+        entries:
+          - reference-id: CAP-001

--- a/threatcatalog.cue
+++ b/threatcatalog.cue
@@ -2,6 +2,8 @@
 @status("stable")
 package gemara
 
+import "list"
+
 @go(gemara)
 
 // ThreatCatalog describes a set of topically-associated threats
@@ -15,6 +17,11 @@ package gemara
 	if threats != _|_ {
 		_uniqueThreatIds: {for i, t in threats {(t.id): i}}
 		groups: [#Group, ...#Group]
+		let _validGroupIds = [for g in groups {g.id}]
+		// Unify the valid ID list with a list.Contains constraint to require each entry's value exists
+		for i, t in threats {
+			_groupValidation: "\(i)": _validGroupIds & list.Contains(t.group)
+		}
 	}
 }
 

--- a/threatcatalog.cue
+++ b/threatcatalog.cue
@@ -18,6 +18,7 @@ import "list"
 		_uniqueThreatIds: {for i, t in threats {(t.id): i}}
 		groups: [#Group, ...#Group]
 		let _validGroupIds = [for g in groups {g.id}]
+
 		// Unify the valid ID list with a list.Contains constraint to require each entry's value exists
 		for i, t in threats {
 			_groupValidation: "\(i)": _validGroupIds & list.Contains(t.group)

--- a/vectorcatalog.cue
+++ b/vectorcatalog.cue
@@ -2,6 +2,8 @@
 @status("experimental")
 package gemara
 
+import "list"
+
 @go(gemara)
 
 // A VectorCatalog is a structured collection of documented vectors,
@@ -17,6 +19,19 @@ package gemara
 	if vectors != _|_ {
 		_uniqueVectorIds: {for i, v in vectors {(v.id): i}}
 		groups: [#Group, ...#Group]
+		let _validGroupIds = [for g in groups {g.id}]
+		// Unify the valid ID list with a list.Contains constraint to require each entry's value exists
+		for i, v in vectors {
+			_groupValidation: "\(i)": _validGroupIds & list.Contains(v.group)
+		}
+		if metadata."applicability-groups" != _|_ {
+			let _validApplicabilityIds = [for ag in metadata."applicability-groups" {ag.id}]
+			for i, v in vectors if v.applicability != _|_ {
+				for j, a in v.applicability {
+					_applicabilityValidation: "\(i)-\(j)": _validApplicabilityIds & list.Contains(a)
+				}
+			}
+		}
 	}
 }
 

--- a/vectorcatalog.cue
+++ b/vectorcatalog.cue
@@ -20,6 +20,7 @@ import "list"
 		_uniqueVectorIds: {for i, v in vectors {(v.id): i}}
 		groups: [#Group, ...#Group]
 		let _validGroupIds = [for g in groups {g.id}]
+
 		// Unify the valid ID list with a list.Contains constraint to require each entry's value exists
 		for i, v in vectors {
 			_groupValidation: "\(i)": _validGroupIds & list.Contains(v.group)


### PR DESCRIPTION
## Description

This PR adds schema constraints to guide authoring:

- Required `group` and `applicability` to be in `groups` and `applicability-groups`, respectively 
- Restrict method types by context in `policy.cue`

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [ ] Audit Log schema (`auditlog.cue`) changes
- [X] Capability Catalog schema (`capabilitycatalog.cue`) changes
- [X] Control Catalog schema (`controlcatalog.cue`) changes
- [ ] Enforcement Log schema (`enforcementlog.cue`) changes
- [ ] Evaluation Log schema (`evaluationlog.cue`) changes
- [X] Guidance Catalog schema (`guidancecatalog.cue`) changes
- [ ] Mapping Document schema (`mappingdocument.cue`) changes
- [X] Policy Document schema (`policy.cue`) changes
- [X] Principle Catalog schema (`principlecatalog.cue`) changes
- [X] Risk Catalog schema (`riskcatalog.cue`) changes
- [X] Threat Catalog schema (`threatcatalog.cue`) changes
- [X] Vector Catalog schema (`vectorcatalog.cue`) changes
- [ ] Other

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->


## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [X] Unit tests added/updated
- [ ] Manual testing performed
- [X] Test data updated (if applicable)

## Related Issues

Closes #371 

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->

 ---

## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [X] This PR has content that was created with AI assistance. 
   - [X]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [X] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.
