### PR TITLE
fix: make reference-id requirement on EntryMapping

### DIFF
--- a/mapping_inline.cue
+++ b/mapping_inline.cue
@@ -42,7 +42,7 @@ package gemara
 // EntryMapping represents how a specific entry maps to a MappingReference.
 #EntryMapping: {
 	// reference-id is the id for a MappingReference entry in the artifact's metadata
-	"reference-id"?: string @go(ReferenceId)
+	"reference-id": string @go(ReferenceId)
 
 	// entry-id is the identifier being mapped to in the referenced artifact
 	"entry-id": string @go(EntryId)


### PR DESCRIPTION
## Description

This PR fixes a bug where `reference-id` was optional in the EntryMapping schema, but implicitly required in EvaluationLog.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [ ] Audit Log schema (`auditlog.cue`) changes
- [ ] Capability Catalog schema (`capabilitycatalog.cue`) changes
- [X] Control Catalog schema (`controlcatalog.cue`) changes
- [ ] Enforcement Log schema (`enforcementlog.cue`) changes
- [X] Evaluation Log schema (`evaluationlog.cue`) changes
- [X] Guidance Catalog schema (`guidancecatalog.cue`) changes
- [ ] Mapping Document schema (`mappingdocument.cue`) changes
- [ ] Policy Document schema (`policy.cue`) changes
- [ ] Principle Catalog schema (`principlecatalog.cue`) changes
- [ ] Risk Catalog schema (`riskcatalog.cue`) changes
- [ ] Threat Catalog schema (`threatcatalog.cue`) changes
- [ ] Vector Catalog schema (`vectorcatalog.cue`) changes
- [ ] Other

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->



 ---

## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [ ] This PR has content that was created with AI assistance. 
   - [ ]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [ ] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.
